### PR TITLE
feat: add GeckoTerminal tools

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,3 +23,5 @@ coverage/
 
 instructions.md
 instructions.md
+
+test_geck_tools.sh

--- a/src/mcp/handler.rs
+++ b/src/mcp/handler.rs
@@ -1,6 +1,10 @@
 use crate::server::NovaServer;
 use crate::{
     error::NovaError,
+    tools::gecko_terminal::{
+        get_networks, get_pool, get_token, GetGeckoNetworksInput, GetGeckoPoolInput,
+        GetGeckoTokenInput,
+    },
     tools::public::{GetBtcPriceInput, GetCatFactInput},
 };
 use serde_json::json;
@@ -123,6 +127,36 @@ pub(crate) async fn handle_tool_call(
                 Err(_) => return Err(NovaError::api_error("Invalid arguments")),
             };
             let output = server.public_tools().get_btc_price(input).await?;
+            serde_json::to_value(output)?
+        }
+        "get_gecko_networks" => {
+            let input: GetGeckoNetworksInput = match serde_json::from_value(tool_call.arguments) {
+                Ok(v) => v,
+                Err(_) => return Err(NovaError::api_error("Invalid arguments")),
+            };
+            let output = get_networks(server.gecko_terminal_tools(), input).await?;
+            serde_json::to_value(output)?
+        }
+        "get_gecko_token" => {
+            let input: GetGeckoTokenInput = match serde_json::from_value(tool_call.arguments) {
+                Ok(v) => v,
+                Err(_) => return Err(NovaError::api_error("Invalid arguments")),
+            };
+            if input.network.trim().is_empty() || input.address.trim().is_empty() {
+                return Err(NovaError::api_error("network and address are required"));
+            }
+            let output = get_token(server.gecko_terminal_tools(), input).await?;
+            serde_json::to_value(output)?
+        }
+        "get_gecko_pool" => {
+            let input: GetGeckoPoolInput = match serde_json::from_value(tool_call.arguments) {
+                Ok(v) => v,
+                Err(_) => return Err(NovaError::api_error("Invalid arguments")),
+            };
+            if input.network.trim().is_empty() || input.address.trim().is_empty() {
+                return Err(NovaError::api_error("network and address are required"));
+            }
+            let output = get_pool(server.gecko_terminal_tools(), input).await?;
             serde_json::to_value(output)?
         }
         _ => {

--- a/src/server.rs
+++ b/src/server.rs
@@ -3,25 +3,35 @@ use crate::error::Result;
 use crate::mcp::dto::Tool;
 // Re-export MCP DTOs under `server` for backward compatibility
 pub use crate::mcp::dto::{McpError, McpRequest, McpResponse, ToolCall, ToolResult};
+use crate::tools::gecko_terminal::GeckoTerminalTools;
 use crate::tools::public::PublicTools;
 use serde_json::json;
 
 pub struct NovaServer {
     public_tools: PublicTools,
+    gecko_terminal_tools: GeckoTerminalTools,
 }
 
 impl NovaServer {
     pub fn new(_config: NovaConfig) -> Self {
         let public_tools = PublicTools::new();
-        Self { public_tools }
+        let gecko_terminal_tools = GeckoTerminalTools::new();
+        Self {
+            public_tools,
+            gecko_terminal_tools,
+        }
     }
 
     pub fn public_tools(&self) -> &PublicTools {
         &self.public_tools
     }
 
+    pub fn gecko_terminal_tools(&self) -> &GeckoTerminalTools {
+        &self.gecko_terminal_tools
+    }
+
     pub fn get_tools(&self) -> Vec<Tool> {
-        vec![
+        let mut tools = vec![
             Tool {
                 name: "get_cat_fact".to_string(),
                 description: "Fetch a random cat fact (catfact.ninja)".to_string(),
@@ -40,7 +50,44 @@ impl NovaServer {
                     "properties": {}
                 }),
             },
-        ]
+        ];
+
+        tools.push(Tool {
+            name: "get_gecko_networks".to_string(),
+            description: "List available networks from GeckoTerminal".to_string(),
+            input_schema: json!({
+                "type": "object",
+                "properties": {}
+            }),
+        });
+
+        tools.push(Tool {
+            name: "get_gecko_token".to_string(),
+            description: "Fetch token info from GeckoTerminal".to_string(),
+            input_schema: json!({
+                "type": "object",
+                "properties": {
+                    "network": { "type": "string" },
+                    "address": { "type": "string" }
+                },
+                "required": ["network", "address"],
+            }),
+        });
+
+        tools.push(Tool {
+            name: "get_gecko_pool".to_string(),
+            description: "Fetch pool info from GeckoTerminal".to_string(),
+            input_schema: json!({
+                "type": "object",
+                "properties": {
+                    "network": { "type": "string" },
+                    "address": { "type": "string" }
+                },
+                "required": ["network", "address"],
+            }),
+        });
+
+        tools
     }
 
     // handler logic is moved into crate::mcp::handler; keep server responsibilities focused

--- a/src/tools/gecko_terminal/dto.rs
+++ b/src/tools/gecko_terminal/dto.rs
@@ -1,0 +1,31 @@
+use serde::{Deserialize, Serialize};
+
+#[derive(Debug, Serialize, Deserialize, Default)]
+pub struct GetGeckoNetworksInput {}
+
+#[derive(Debug, Serialize, Deserialize)]
+pub struct GetGeckoNetworksOutput {
+    pub networks: serde_json::Value,
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+pub struct GetGeckoTokenInput {
+    pub network: String,
+    pub address: String,
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+pub struct GetGeckoTokenOutput {
+    pub token: serde_json::Value,
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+pub struct GetGeckoPoolInput {
+    pub network: String,
+    pub address: String,
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+pub struct GetGeckoPoolOutput {
+    pub pool: serde_json::Value,
+}

--- a/src/tools/gecko_terminal/handler.rs
+++ b/src/tools/gecko_terminal/handler.rs
@@ -1,0 +1,27 @@
+use super::dto::{
+    GetGeckoNetworksInput, GetGeckoNetworksOutput, GetGeckoPoolInput, GetGeckoPoolOutput,
+    GetGeckoTokenInput, GetGeckoTokenOutput,
+};
+use super::implementation::GeckoTerminalTools;
+use crate::error::Result;
+
+pub async fn get_networks(
+    tools: &GeckoTerminalTools,
+    input: GetGeckoNetworksInput,
+) -> Result<GetGeckoNetworksOutput> {
+    tools.get_networks(input).await
+}
+
+pub async fn get_token(
+    tools: &GeckoTerminalTools,
+    input: GetGeckoTokenInput,
+) -> Result<GetGeckoTokenOutput> {
+    tools.get_token(input).await
+}
+
+pub async fn get_pool(
+    tools: &GeckoTerminalTools,
+    input: GetGeckoPoolInput,
+) -> Result<GetGeckoPoolOutput> {
+    tools.get_pool(input).await
+}

--- a/src/tools/gecko_terminal/helpers.rs
+++ b/src/tools/gecko_terminal/helpers.rs
@@ -1,0 +1,8 @@
+pub(crate) fn build_url(base: &str, segments: &[&str]) -> String {
+    let mut url = base.trim_end_matches('/').to_string();
+    for segment in segments {
+        url.push('/');
+        url.push_str(segment.trim_matches('/'));
+    }
+    url
+}

--- a/src/tools/gecko_terminal/implementation.rs
+++ b/src/tools/gecko_terminal/implementation.rs
@@ -1,0 +1,93 @@
+use super::dto::{
+    GetGeckoNetworksInput, GetGeckoNetworksOutput, GetGeckoPoolInput, GetGeckoPoolOutput,
+    GetGeckoTokenInput, GetGeckoTokenOutput,
+};
+use super::helpers::build_url;
+use crate::error::{NovaError, Result};
+use std::time::Duration;
+
+#[derive(Clone)]
+pub struct GeckoTerminalTools {
+    http: reqwest::Client,
+    base_url: String,
+}
+
+impl GeckoTerminalTools {
+    pub fn new() -> Self {
+        let http = reqwest::Client::builder()
+            .timeout(Duration::from_secs(10))
+            .user_agent("Nova-MCP/0.1.0")
+            .build()
+            .unwrap_or_else(|e| {
+                tracing::error!("Failed to build HTTP client: {}", e);
+                reqwest::Client::new()
+            });
+        Self {
+            http,
+            base_url: "https://api.geckoterminal.com/api/v2".to_string(),
+        }
+    }
+
+    pub async fn get_networks(
+        &self,
+        _input: GetGeckoNetworksInput,
+    ) -> Result<GetGeckoNetworksOutput> {
+        let url = build_url(&self.base_url, &["networks"]);
+        let networks = self
+            .http
+            .get(&url)
+            .send()
+            .await
+            .map_err(NovaError::NetworkError)?
+            .error_for_status()
+            .map_err(NovaError::NetworkError)?
+            .json::<serde_json::Value>()
+            .await
+            .map_err(NovaError::NetworkError)?;
+        Ok(GetGeckoNetworksOutput { networks })
+    }
+
+    pub async fn get_token(&self, input: GetGeckoTokenInput) -> Result<GetGeckoTokenOutput> {
+        let url = build_url(
+            &self.base_url,
+            &["networks", &input.network, "tokens", &input.address],
+        );
+        let token = self
+            .http
+            .get(&url)
+            .send()
+            .await
+            .map_err(NovaError::NetworkError)?
+            .error_for_status()
+            .map_err(NovaError::NetworkError)?
+            .json::<serde_json::Value>()
+            .await
+            .map_err(NovaError::NetworkError)?;
+        Ok(GetGeckoTokenOutput { token })
+    }
+
+    pub async fn get_pool(&self, input: GetGeckoPoolInput) -> Result<GetGeckoPoolOutput> {
+        let url = build_url(
+            &self.base_url,
+            &["networks", &input.network, "pools", &input.address],
+        );
+        let pool = self
+            .http
+            .get(&url)
+            .send()
+            .await
+            .map_err(NovaError::NetworkError)?
+            .error_for_status()
+            .map_err(NovaError::NetworkError)?
+            .json::<serde_json::Value>()
+            .await
+            .map_err(NovaError::NetworkError)?;
+        Ok(GetGeckoPoolOutput { pool })
+    }
+}
+
+impl Default for GeckoTerminalTools {
+    fn default() -> Self {
+        Self::new()
+    }
+}

--- a/src/tools/gecko_terminal/mod.rs
+++ b/src/tools/gecko_terminal/mod.rs
@@ -1,0 +1,11 @@
+pub mod dto;
+pub mod handler;
+pub mod helpers;
+pub mod implementation;
+
+pub use dto::{
+    GetGeckoNetworksInput, GetGeckoNetworksOutput, GetGeckoPoolInput, GetGeckoPoolOutput,
+    GetGeckoTokenInput, GetGeckoTokenOutput,
+};
+pub use handler::{get_networks, get_pool, get_token};
+pub use implementation::GeckoTerminalTools;

--- a/src/tools/mod.rs
+++ b/src/tools/mod.rs
@@ -1,3 +1,11 @@
+pub mod gecko_terminal;
 pub mod public;
 
-pub use public::*;
+pub use gecko_terminal::{
+    get_networks, get_pool, get_token, GeckoTerminalTools, GetGeckoNetworksInput,
+    GetGeckoNetworksOutput, GetGeckoPoolInput, GetGeckoPoolOutput, GetGeckoTokenInput,
+    GetGeckoTokenOutput,
+};
+pub use public::{
+    GetBtcPriceInput, GetBtcPriceOutput, GetCatFactInput, GetCatFactOutput, PublicTools,
+};

--- a/tests/server_list_tools.rs
+++ b/tests/server_list_tools.rs
@@ -1,11 +1,14 @@
 use nova_mcp::{NovaConfig, NovaServer};
 
 #[test]
-fn list_tools_has_only_two() {
+fn list_tools_contains_expected() {
     let server = NovaServer::new(NovaConfig::default());
     let tools = server.get_tools();
-    assert_eq!(tools.len(), 2);
+    assert_eq!(tools.len(), 5);
     let names: Vec<_> = tools.iter().map(|t| t.name.as_str()).collect();
     assert!(names.contains(&"get_cat_fact"));
     assert!(names.contains(&"get_btc_price"));
+    assert!(names.contains(&"get_gecko_networks"));
+    assert!(names.contains(&"get_gecko_token"));
+    assert!(names.contains(&"get_gecko_pool"));
 }


### PR DESCRIPTION
## Summary
- add GeckoTerminal tools module for networks, tokens, and pools
- register new GeckoTerminal tools with server and MCP handler
- update server list tools test for new endpoints

## Testing
- `cargo check`
- `cargo test`


------
https://chatgpt.com/codex/tasks/task_e_68c5d5a24308832184d4d5b9d6d6007a