### PR TITLE
Add Sled-backed plugin management and HTTP endpoints

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -181,6 +181,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "46c5e41b57b8bba42a04676d81cb89e9ee8e859a1a66f80a5a72e1cb76b34d43"
 
 [[package]]
+name = "byteorder"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
+
+[[package]]
 name = "bytes"
 version = "1.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -231,6 +237,30 @@ name = "core-foundation-sys"
 version = "0.8.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b"
+
+[[package]]
+name = "crc32fast"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9481c1c90cbf2ac953f07c8d4a58aa3945c425b7185c9154d67a65e4230da511"
+dependencies = [
+ "cfg-if",
+]
+
+[[package]]
+name = "crossbeam-epoch"
+version = "0.9.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5b82ac4a3c2ca9c3460964f020e1402edd5753411d7737aa39c3714ad1b5420e"
+dependencies = [
+ "crossbeam-utils",
+]
+
+[[package]]
+name = "crossbeam-utils"
+version = "0.8.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d0a5c400df2834b80a4c3327b3aad3a4c4cd4de0629063962b03235697506a28"
 
 [[package]]
 name = "displaydoc"
@@ -317,6 +347,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "fs2"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9564fc758e15025b46aa6643b1b77d047d1a56a1aea6e01002ac0c7026876213"
+dependencies = [
+ "libc",
+ "winapi",
+]
+
+[[package]]
 name = "futures-channel"
 version = "0.3.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -362,6 +402,15 @@ dependencies = [
  "pin-project-lite",
  "pin-utils",
  "slab",
+]
+
+[[package]]
+name = "fxhash"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c31b6d751ae2c7f11320402d34e41349dd1016f8d5d45e48c4312bc8625af50c"
+dependencies = [
+ "byteorder",
 ]
 
 [[package]]
@@ -691,6 +740,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "instant"
+version = "0.1.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e0242819d153cba4b4b05a5a8f2a7e9bbf97b6055b2a002b395c96b5ff3c0222"
+dependencies = [
+ "cfg-if",
+]
+
+[[package]]
 name = "io-uring"
 version = "0.7.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -845,6 +903,7 @@ dependencies = [
  "reqwest",
  "serde",
  "serde_json",
+ "sled",
  "thiserror",
  "tokio",
  "tokio-test",
@@ -933,12 +992,37 @@ dependencies = [
 
 [[package]]
 name = "parking_lot"
+version = "0.11.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7d17b78036a60663b797adeaee46f5c9dfebb86948d1255007a1d6be0271ff99"
+dependencies = [
+ "instant",
+ "lock_api",
+ "parking_lot_core 0.8.6",
+]
+
+[[package]]
+name = "parking_lot"
 version = "0.12.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "70d58bf43669b5795d1576d0641cfb6fbb2057bf629506267a92807158584a13"
 dependencies = [
  "lock_api",
- "parking_lot_core",
+ "parking_lot_core 0.9.11",
+]
+
+[[package]]
+name = "parking_lot_core"
+version = "0.8.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "60a2cfe6f0ad2bfc16aefa463b497d5c7a5ecd44a23efa72aa342d90177356dc"
+dependencies = [
+ "cfg-if",
+ "instant",
+ "libc",
+ "redox_syscall 0.2.16",
+ "smallvec",
+ "winapi",
 ]
 
 [[package]]
@@ -949,7 +1033,7 @@ checksum = "bc838d2a56b5b1a6c25f55575dfc605fabb63bb2365f6c2353ef9159aa69e4a5"
 dependencies = [
  "cfg-if",
  "libc",
- "redox_syscall",
+ "redox_syscall 0.5.17",
  "smallvec",
  "windows-targets 0.52.6",
 ]
@@ -1010,6 +1094,15 @@ name = "r-efi"
 version = "5.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "69cdb34c158ceb288df11e18b4bd39de994f6657d83847bdffdbd7f346754b0f"
+
+[[package]]
+name = "redox_syscall"
+version = "0.2.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fb5a58c1855b4b6819d59012155603f0b22ad30cad752600aadfcb695265519a"
+dependencies = [
+ "bitflags 1.3.2",
+]
 
 [[package]]
 name = "redox_syscall"
@@ -1250,6 +1343,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7a2ae44ef20feb57a68b23d846850f861394c2e02dc425a50098ae8c90267589"
 
 [[package]]
+name = "sled"
+version = "0.34.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7f96b4737c2ce5987354855aed3797279def4ebf734436c6aa4552cf8e169935"
+dependencies = [
+ "crc32fast",
+ "crossbeam-epoch",
+ "crossbeam-utils",
+ "fs2",
+ "fxhash",
+ "libc",
+ "log",
+ "parking_lot 0.11.2",
+]
+
+[[package]]
 name = "smallvec"
 version = "1.15.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1399,7 +1508,7 @@ dependencies = [
  "io-uring",
  "libc",
  "mio",
- "parking_lot",
+ "parking_lot 0.12.4",
  "pin-project-lite",
  "signal-hook-registry",
  "slab",
@@ -1750,6 +1859,28 @@ dependencies = [
  "js-sys",
  "wasm-bindgen",
 ]
+
+[[package]]
+name = "winapi"
+version = "0.3.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c839a674fcd7a98952e593242ea400abe93992746761e38641405d28b00f419"
+dependencies = [
+ "winapi-i686-pc-windows-gnu",
+ "winapi-x86_64-pc-windows-gnu",
+]
+
+[[package]]
+name = "winapi-i686-pc-windows-gnu"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
+
+[[package]]
+name = "winapi-x86_64-pc-windows-gnu"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
 name = "windows-core"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,6 +31,9 @@ hyper = { version = "1" }
 anyhow = "1.0"
 thiserror = "1.0"
 
+# Storage
+sled = "0.34"
+
 # Logging
 tracing = "0.1"
 tracing-subscriber = { version = "0.3", features = ["env-filter"] }

--- a/examples/test_client.rs
+++ b/examples/test_client.rs
@@ -1,14 +1,16 @@
 // Minimal example: call GeckoTerminal tools directly via NovaServer
 use anyhow::Result;
+use nova_mcp::plugins::PluginManager;
 use nova_mcp::server::ToolCall;
 use nova_mcp::{NovaConfig, NovaServer};
 use serde_json::json;
+use std::sync::Arc;
 
 #[tokio::main]
 async fn main() -> Result<()> {
     tracing_subscriber::fmt::init();
 
-    let server = NovaServer::new(NovaConfig::default());
+    let server = build_server()?;
     println!("Available tools:");
     for t in server.get_tools() {
         println!(" - {}: {}", t.name, t.description);
@@ -32,4 +34,13 @@ async fn main() -> Result<()> {
         server.handle_tool_call(trending).await?.content
     );
     Ok(())
+}
+
+fn build_server() -> Result<NovaServer> {
+    let config = NovaConfig::default();
+    let db = sled::Config::new().temporary(true).open()?;
+    let user_tree = db.open_tree("user_plugins")?;
+    let group_tree = db.open_tree("group_plugins")?;
+    let plugin_manager = Arc::new(PluginManager::new(user_tree, group_tree));
+    Ok(NovaServer::new(config, plugin_manager))
 }

--- a/src/error.rs
+++ b/src/error.rs
@@ -16,6 +16,9 @@ pub enum NovaError {
     #[error("Configuration error: {0}")]
     ConfigError(String),
 
+    #[error("Validation error: {message}")]
+    ValidationError { message: String },
+
     #[error("Pool not found: {address}")]
     PoolNotFound { address: String },
 
@@ -24,6 +27,19 @@ pub enum NovaError {
 
     #[error("Invalid address: {address}")]
     InvalidAddress { address: String },
+
+    #[error("Plugin not found: {plugin_id}")]
+    PluginNotFound { plugin_id: u64 },
+
+    #[error("Plugin {plugin_id} is not enabled for {context_type} {context_id}")]
+    PluginNotEnabled {
+        plugin_id: u64,
+        context_type: String,
+        context_id: String,
+    },
+
+    #[error("Storage error: {0}")]
+    StorageError(#[from] sled::Error),
 
     #[error("Rate limit exceeded for API: {api}")]
     RateLimitExceeded { api: String },
@@ -43,5 +59,27 @@ impl NovaError {
 
     pub fn internal(msg: impl Into<String>) -> Self {
         NovaError::Internal(msg.into())
+    }
+
+    pub fn validation_error(msg: impl Into<String>) -> Self {
+        NovaError::ValidationError {
+            message: msg.into(),
+        }
+    }
+
+    pub fn plugin_not_found(plugin_id: u64) -> Self {
+        NovaError::PluginNotFound { plugin_id }
+    }
+
+    pub fn plugin_not_enabled(
+        plugin_id: u64,
+        context_type: impl Into<String>,
+        context_id: impl Into<String>,
+    ) -> Self {
+        NovaError::PluginNotEnabled {
+            plugin_id,
+            context_type: context_type.into(),
+            context_id: context_id.into(),
+        }
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -3,10 +3,12 @@ pub mod config;
 pub mod error;
 pub mod http;
 pub mod mcp;
+pub mod plugins;
 pub mod server;
 pub mod tools;
 
 pub use auth::ApiKeyAuth;
 pub use config::NovaConfig;
 pub use error::{NovaError, Result};
+pub use plugins::PluginManager;
 pub use server::NovaServer;

--- a/src/plugins/dto.rs
+++ b/src/plugins/dto.rs
@@ -1,0 +1,108 @@
+use serde::{Deserialize, Serialize};
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct PluginRegistrationRequest {
+    pub name: String,
+    pub description: String,
+    pub owner_id: String,
+    pub scopes: Vec<String>,
+    pub endpoint: String,
+    #[serde(default)]
+    pub icon_url: Option<String>,
+    pub trust_level: String,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct PluginMetadata {
+    pub plugin_id: u64,
+    pub name: String,
+    pub description: String,
+    pub owner_id: String,
+    pub scopes: Vec<String>,
+    pub endpoint: String,
+    #[serde(default)]
+    pub icon_url: Option<String>,
+    pub trust_level: String,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, Default)]
+pub struct PluginUpdateRequest {
+    #[serde(default)]
+    pub name: Option<String>,
+    #[serde(default)]
+    pub description: Option<String>,
+    #[serde(default)]
+    pub owner_id: Option<String>,
+    #[serde(default)]
+    pub scopes: Option<Vec<String>>,
+    #[serde(default)]
+    pub endpoint: Option<String>,
+    #[serde(default)]
+    pub icon_url: Option<Option<String>>,
+    #[serde(default)]
+    pub trust_level: Option<String>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "lowercase")]
+pub enum PluginContextType {
+    User,
+    Group,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct PluginInvocationRequest {
+    pub context_type: PluginContextType,
+    pub context_id: String,
+    #[serde(default)]
+    pub arguments: serde_json::Value,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct PluginInvocationPayload {
+    pub context_type: PluginContextType,
+    pub context_id: String,
+    pub arguments: serde_json::Value,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct PluginEnableRequest {
+    pub context_type: PluginContextType,
+    pub context_id: String,
+    pub plugin_id: u64,
+    pub enable: bool,
+    #[serde(default)]
+    pub added_by: Option<String>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct PluginEnablementStatus {
+    pub context_type: PluginContextType,
+    pub context_id: String,
+    pub plugin_id: u64,
+    pub enabled: bool,
+    pub consent_ts: i64,
+    #[serde(default)]
+    pub added_by: Option<String>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ErrorResponse {
+    pub error: String,
+    #[serde(default)]
+    pub details: Option<serde_json::Value>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct UserPluginRecord {
+    pub enabled: bool,
+    pub consent_ts: i64,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct GroupPluginRecord {
+    pub enabled: bool,
+    #[serde(default)]
+    pub added_by: Option<String>,
+    pub consent_ts: i64,
+}

--- a/src/plugins/handler.rs
+++ b/src/plugins/handler.rs
@@ -1,0 +1,88 @@
+use axum::{
+    extract::{Path, State},
+    http::HeaderMap,
+    http::StatusCode,
+    Json,
+};
+
+use crate::http::AppState;
+
+use super::dto::{
+    ErrorResponse, PluginEnableRequest, PluginEnablementStatus, PluginInvocationRequest,
+    PluginMetadata, PluginRegistrationRequest, PluginUpdateRequest,
+};
+use super::helpers::{authorize_request, map_error};
+
+pub(crate) async fn register_plugin(
+    State(state): State<AppState>,
+    headers: HeaderMap,
+    Json(request): Json<PluginRegistrationRequest>,
+) -> Result<(StatusCode, Json<PluginMetadata>), (StatusCode, Json<ErrorResponse>)> {
+    let _ = authorize_request(&state, &headers).await?;
+    match state.plugin_manager().register_plugin(request) {
+        Ok(metadata) => Ok((StatusCode::CREATED, Json(metadata))),
+        Err(err) => Err(map_error(err)),
+    }
+}
+
+pub(crate) async fn unregister_plugin(
+    State(state): State<AppState>,
+    headers: HeaderMap,
+    Path(plugin_id): Path<u64>,
+) -> Result<StatusCode, (StatusCode, Json<ErrorResponse>)> {
+    let _ = authorize_request(&state, &headers).await?;
+    match state.plugin_manager().unregister_plugin(plugin_id) {
+        Ok(()) => Ok(StatusCode::NO_CONTENT),
+        Err(err) => Err(map_error(err)),
+    }
+}
+
+pub(crate) async fn update_plugin(
+    State(state): State<AppState>,
+    headers: HeaderMap,
+    Path(plugin_id): Path<u64>,
+    Json(request): Json<PluginUpdateRequest>,
+) -> Result<Json<PluginMetadata>, (StatusCode, Json<ErrorResponse>)> {
+    let _ = authorize_request(&state, &headers).await?;
+    match state.plugin_manager().update_plugin(plugin_id, request) {
+        Ok(metadata) => Ok(Json(metadata)),
+        Err(err) => Err(map_error(err)),
+    }
+}
+
+pub(crate) async fn list_plugins(
+    State(state): State<AppState>,
+    headers: HeaderMap,
+) -> Result<Json<Vec<PluginMetadata>>, (StatusCode, Json<ErrorResponse>)> {
+    let _ = authorize_request(&state, &headers).await?;
+    match state.plugin_manager().list_plugins() {
+        Ok(list) => Ok(Json(list)),
+        Err(err) => Err(map_error(err)),
+    }
+}
+
+pub(crate) async fn invoke_plugin(
+    State(state): State<AppState>,
+    headers: HeaderMap,
+    Path(plugin_id): Path<u64>,
+    Json(request): Json<PluginInvocationRequest>,
+) -> Result<Json<serde_json::Value>, (StatusCode, Json<ErrorResponse>)> {
+    let _ = authorize_request(&state, &headers).await?;
+    let manager = state.plugin_manager_arc();
+    match manager.invoke_plugin(plugin_id, request).await {
+        Ok(value) => Ok(Json(value)),
+        Err(err) => Err(map_error(err)),
+    }
+}
+
+pub(crate) async fn set_plugin_enablement(
+    State(state): State<AppState>,
+    headers: HeaderMap,
+    Json(request): Json<PluginEnableRequest>,
+) -> Result<Json<PluginEnablementStatus>, (StatusCode, Json<ErrorResponse>)> {
+    let _ = authorize_request(&state, &headers).await?;
+    match state.plugin_manager().set_enablement(request) {
+        Ok(status) => Ok(Json(status)),
+        Err(err) => Err(map_error(err)),
+    }
+}

--- a/src/plugins/helpers.rs
+++ b/src/plugins/helpers.rs
@@ -1,0 +1,62 @@
+use axum::{
+    http::{HeaderMap, StatusCode},
+    Json,
+};
+
+use crate::error::NovaError;
+use crate::http::{check_rate_limit, AppState};
+
+use super::dto::ErrorResponse;
+
+pub(crate) async fn authorize_request(
+    state: &AppState,
+    headers: &HeaderMap,
+) -> Result<String, (StatusCode, Json<ErrorResponse>)> {
+    let header_name = state.auth().header_name().to_string();
+    let presented = headers
+        .get(header_name.as_str())
+        .and_then(|value| value.to_str().ok());
+
+    if !state.auth().validate(presented) {
+        let body = ErrorResponse {
+            error: "Unauthorized".to_string(),
+            details: None,
+        };
+        return Err((StatusCode::UNAUTHORIZED, Json(body)));
+    }
+
+    let key = presented.unwrap_or("anonymous").to_string();
+    if let Some(code) = check_rate_limit(state, &key).await {
+        let body = ErrorResponse {
+            error: "Rate limit exceeded".to_string(),
+            details: None,
+        };
+        return Err((code, Json(body)));
+    }
+
+    Ok(key)
+}
+
+pub(crate) fn map_error(err: NovaError) -> (StatusCode, Json<ErrorResponse>) {
+    let (status, details) = match &err {
+        NovaError::PluginNotFound { .. } => (StatusCode::NOT_FOUND, None),
+        NovaError::PluginNotEnabled { .. } => (StatusCode::FORBIDDEN, None),
+        NovaError::ValidationError { .. } => (StatusCode::BAD_REQUEST, None),
+        NovaError::RateLimitExceeded { .. } => (StatusCode::TOO_MANY_REQUESTS, None),
+        NovaError::ApiError(_) | NovaError::NetworkError(_) => (StatusCode::BAD_GATEWAY, None),
+        NovaError::StorageError(_) => (StatusCode::SERVICE_UNAVAILABLE, None),
+        NovaError::SerializationError(_) => (StatusCode::INTERNAL_SERVER_ERROR, None),
+        NovaError::ConfigError(_) => (StatusCode::BAD_REQUEST, None),
+        NovaError::Internal(_) => (StatusCode::INTERNAL_SERVER_ERROR, None),
+        NovaError::PoolNotFound { .. }
+        | NovaError::TokenNotFound { .. }
+        | NovaError::InvalidAddress { .. } => (StatusCode::BAD_REQUEST, None),
+    };
+
+    let body = ErrorResponse {
+        error: err.to_string(),
+        details,
+    };
+
+    (status, Json(body))
+}

--- a/src/plugins/manager.rs
+++ b/src/plugins/manager.rs
@@ -1,0 +1,396 @@
+use std::collections::HashMap;
+use std::str;
+use std::sync::atomic::{AtomicU64, Ordering};
+use std::sync::RwLock;
+
+use chrono::Utc;
+use reqwest::Client;
+
+use crate::error::{NovaError, Result};
+
+use super::dto::{
+    GroupPluginRecord, PluginContextType, PluginEnableRequest, PluginEnablementStatus,
+    PluginInvocationPayload, PluginInvocationRequest, PluginMetadata, PluginRegistrationRequest,
+    PluginUpdateRequest, UserPluginRecord,
+};
+
+pub struct PluginManager {
+    plugins: RwLock<HashMap<u64, PluginMetadata>>,
+    user_tree: sled::Tree,
+    group_tree: sled::Tree,
+    sequence: AtomicU64,
+    http_client: Client,
+}
+
+impl PluginManager {
+    pub fn new(user_tree: sled::Tree, group_tree: sled::Tree) -> Self {
+        Self {
+            plugins: RwLock::new(HashMap::new()),
+            user_tree,
+            group_tree,
+            sequence: AtomicU64::new(1),
+            http_client: Client::new(),
+        }
+    }
+
+    pub fn register_plugin(&self, request: PluginRegistrationRequest) -> Result<PluginMetadata> {
+        if request.name.trim().is_empty() {
+            return Err(NovaError::validation_error("Plugin name cannot be empty"));
+        }
+        if request.endpoint.trim().is_empty() {
+            return Err(NovaError::validation_error(
+                "Plugin endpoint cannot be empty",
+            ));
+        }
+
+        let plugin_id = self.sequence.fetch_add(1, Ordering::SeqCst);
+        let metadata = PluginMetadata {
+            plugin_id,
+            name: request.name,
+            description: request.description,
+            owner_id: request.owner_id,
+            scopes: request.scopes,
+            endpoint: request.endpoint,
+            icon_url: request.icon_url,
+            trust_level: request.trust_level,
+        };
+
+        let mut guard = self
+            .plugins
+            .write()
+            .map_err(|_| NovaError::internal("Plugin registry lock poisoned"))?;
+        guard.insert(plugin_id, metadata.clone());
+
+        Ok(metadata)
+    }
+
+    pub fn unregister_plugin(&self, plugin_id: u64) -> Result<()> {
+        let mut guard = self
+            .plugins
+            .write()
+            .map_err(|_| NovaError::internal("Plugin registry lock poisoned"))?;
+        let removed = guard.remove(&plugin_id);
+        drop(guard);
+
+        if removed.is_none() {
+            return Err(NovaError::plugin_not_found(plugin_id));
+        }
+
+        self.clear_plugin_entries(plugin_id)?;
+        Ok(())
+    }
+
+    pub fn update_plugin(
+        &self,
+        plugin_id: u64,
+        update: PluginUpdateRequest,
+    ) -> Result<PluginMetadata> {
+        let mut guard = self
+            .plugins
+            .write()
+            .map_err(|_| NovaError::internal("Plugin registry lock poisoned"))?;
+        let plugin = guard
+            .get_mut(&plugin_id)
+            .ok_or_else(|| NovaError::plugin_not_found(plugin_id))?;
+
+        if let Some(name) = update.name {
+            if name.trim().is_empty() {
+                return Err(NovaError::validation_error("Plugin name cannot be empty"));
+            }
+            plugin.name = name;
+        }
+        if let Some(description) = update.description {
+            plugin.description = description;
+        }
+        if let Some(owner_id) = update.owner_id {
+            plugin.owner_id = owner_id;
+        }
+        if let Some(scopes) = update.scopes {
+            plugin.scopes = scopes;
+        }
+        if let Some(endpoint) = update.endpoint {
+            if endpoint.trim().is_empty() {
+                return Err(NovaError::validation_error(
+                    "Plugin endpoint cannot be empty",
+                ));
+            }
+            plugin.endpoint = endpoint;
+        }
+        if let Some(icon_url) = update.icon_url {
+            plugin.icon_url = icon_url;
+        }
+        if let Some(trust_level) = update.trust_level {
+            plugin.trust_level = trust_level;
+        }
+
+        Ok(plugin.clone())
+    }
+
+    pub fn list_plugins(&self) -> Result<Vec<PluginMetadata>> {
+        let guard = self
+            .plugins
+            .read()
+            .map_err(|_| NovaError::internal("Plugin registry lock poisoned"))?;
+        Ok(guard.values().cloned().collect())
+    }
+
+    pub fn get_plugin(&self, plugin_id: u64) -> Result<PluginMetadata> {
+        let guard = self
+            .plugins
+            .read()
+            .map_err(|_| NovaError::internal("Plugin registry lock poisoned"))?;
+        guard
+            .get(&plugin_id)
+            .cloned()
+            .ok_or_else(|| NovaError::plugin_not_found(plugin_id))
+    }
+
+    pub fn set_enablement(&self, request: PluginEnableRequest) -> Result<PluginEnablementStatus> {
+        self.ensure_plugin_exists(request.plugin_id)?;
+
+        match request.context_type {
+            PluginContextType::User => self.set_user_enablement(&request),
+            PluginContextType::Group => self.set_group_enablement(&request),
+        }
+    }
+
+    pub fn is_enabled(
+        &self,
+        plugin_id: u64,
+        context_type: PluginContextType,
+        context_id: &str,
+    ) -> Result<bool> {
+        match context_type {
+            PluginContextType::User => self.read_user_enablement(context_id, plugin_id),
+            PluginContextType::Group => self.read_group_enablement(context_id, plugin_id),
+        }
+    }
+
+    pub async fn invoke_plugin(
+        &self,
+        plugin_id: u64,
+        request: PluginInvocationRequest,
+    ) -> Result<serde_json::Value> {
+        let metadata = self.get_plugin(plugin_id)?;
+        let PluginInvocationRequest {
+            context_type,
+            context_id,
+            arguments,
+        } = request;
+
+        if !self.is_enabled(plugin_id, context_type.clone(), &context_id)? {
+            return Err(NovaError::plugin_not_enabled(
+                plugin_id,
+                Self::context_type_label(&context_type),
+                context_id,
+            ));
+        }
+
+        let payload = PluginInvocationPayload {
+            context_type,
+            context_id,
+            arguments,
+        };
+
+        let response = self
+            .http_client
+            .post(&metadata.endpoint)
+            .json(&payload)
+            .send()
+            .await
+            .map_err(NovaError::from)?;
+
+        if !response.status().is_success() {
+            let status = response.status();
+            let body = response.text().await.unwrap_or_default();
+            return Err(NovaError::api_error(format!(
+                "Plugin endpoint returned {}: {}",
+                status, body
+            )));
+        }
+
+        let json = response.json().await.map_err(NovaError::from)?;
+        Ok(json)
+    }
+
+    fn ensure_plugin_exists(&self, plugin_id: u64) -> Result<()> {
+        let guard = self
+            .plugins
+            .read()
+            .map_err(|_| NovaError::internal("Plugin registry lock poisoned"))?;
+        if guard.contains_key(&plugin_id) {
+            Ok(())
+        } else {
+            Err(NovaError::plugin_not_found(plugin_id))
+        }
+    }
+
+    fn set_user_enablement(&self, request: &PluginEnableRequest) -> Result<PluginEnablementStatus> {
+        let key = Self::context_key(&request.context_id, request.plugin_id);
+        let now = Utc::now().timestamp();
+        let existing = self.user_tree.get(&key).map_err(NovaError::from)?;
+
+        let mut record = if let Some(value) = existing {
+            serde_json::from_slice::<UserPluginRecord>(&value).map_err(|e| {
+                NovaError::internal(format!("Failed to parse user plugin record: {}", e))
+            })?
+        } else {
+            UserPluginRecord {
+                enabled: false,
+                consent_ts: now,
+            }
+        };
+
+        if request.enable {
+            record.enabled = true;
+            record.consent_ts = now;
+        } else {
+            record.enabled = false;
+        }
+
+        let encoded = serde_json::to_vec(&record).map_err(|e| {
+            NovaError::internal(format!("Failed to encode user plugin record: {}", e))
+        })?;
+        self.user_tree
+            .insert(key, encoded)
+            .map_err(NovaError::from)?;
+        self.user_tree.flush().map_err(NovaError::from)?;
+
+        Ok(PluginEnablementStatus {
+            context_type: PluginContextType::User,
+            context_id: request.context_id.clone(),
+            plugin_id: request.plugin_id,
+            enabled: record.enabled,
+            consent_ts: record.consent_ts,
+            added_by: None,
+        })
+    }
+
+    fn set_group_enablement(
+        &self,
+        request: &PluginEnableRequest,
+    ) -> Result<PluginEnablementStatus> {
+        let key = Self::context_key(&request.context_id, request.plugin_id);
+        let now = Utc::now().timestamp();
+        let existing = self.group_tree.get(&key).map_err(NovaError::from)?;
+
+        let mut record = if let Some(value) = existing {
+            serde_json::from_slice::<GroupPluginRecord>(&value).map_err(|e| {
+                NovaError::internal(format!("Failed to parse group plugin record: {}", e))
+            })?
+        } else {
+            GroupPluginRecord {
+                enabled: false,
+                added_by: None,
+                consent_ts: now,
+            }
+        };
+
+        if request.enable {
+            let added_by = request.added_by.clone().ok_or_else(|| {
+                NovaError::validation_error(
+                    "added_by is required when enabling a plugin for a group",
+                )
+            })?;
+            record.enabled = true;
+            record.added_by = Some(added_by);
+            record.consent_ts = now;
+        } else {
+            record.enabled = false;
+        }
+
+        let encoded = serde_json::to_vec(&record).map_err(|e| {
+            NovaError::internal(format!("Failed to encode group plugin record: {}", e))
+        })?;
+        self.group_tree
+            .insert(key, encoded)
+            .map_err(NovaError::from)?;
+        self.group_tree.flush().map_err(NovaError::from)?;
+
+        Ok(PluginEnablementStatus {
+            context_type: PluginContextType::Group,
+            context_id: request.context_id.clone(),
+            plugin_id: request.plugin_id,
+            enabled: record.enabled,
+            consent_ts: record.consent_ts,
+            added_by: record.added_by.clone(),
+        })
+    }
+
+    fn read_user_enablement(&self, context_id: &str, plugin_id: u64) -> Result<bool> {
+        let key = Self::context_key(context_id, plugin_id);
+        let value = self.user_tree.get(&key).map_err(NovaError::from)?;
+        if let Some(bytes) = value {
+            let record: UserPluginRecord = serde_json::from_slice(&bytes).map_err(|e| {
+                NovaError::internal(format!("Failed to parse user plugin record: {}", e))
+            })?;
+            Ok(record.enabled)
+        } else {
+            Ok(false)
+        }
+    }
+
+    fn read_group_enablement(&self, context_id: &str, plugin_id: u64) -> Result<bool> {
+        let key = Self::context_key(context_id, plugin_id);
+        let value = self.group_tree.get(&key).map_err(NovaError::from)?;
+        if let Some(bytes) = value {
+            let record: GroupPluginRecord = serde_json::from_slice(&bytes).map_err(|e| {
+                NovaError::internal(format!("Failed to parse group plugin record: {}", e))
+            })?;
+            Ok(record.enabled)
+        } else {
+            Ok(false)
+        }
+    }
+
+    fn clear_plugin_entries(&self, plugin_id: u64) -> Result<()> {
+        self.clear_entries_for_tree(&self.user_tree, plugin_id)?;
+        self.clear_entries_for_tree(&self.group_tree, plugin_id)?;
+        Ok(())
+    }
+
+    fn clear_entries_for_tree(&self, tree: &sled::Tree, plugin_id: u64) -> Result<()> {
+        let mut keys_to_remove = Vec::new();
+        for item in tree.iter() {
+            let entry = item.map_err(NovaError::from)?;
+            let key_bytes = entry.0.to_vec();
+            if Self::matches_plugin(&key_bytes, plugin_id)? {
+                keys_to_remove.push(key_bytes);
+            }
+        }
+
+        for key in keys_to_remove {
+            tree.remove(key).map_err(NovaError::from)?;
+        }
+        tree.flush().map_err(NovaError::from)?;
+        Ok(())
+    }
+
+    fn matches_plugin(key: &[u8], plugin_id: u64) -> Result<bool> {
+        let key_str = str::from_utf8(key).map_err(|e| {
+            NovaError::internal(format!("Failed to parse sled key as UTF-8: {}", e))
+        })?;
+        if let Some((_context, id_str)) = key_str.rsplit_once('|') {
+            let parsed = id_str.parse::<u64>().map_err(|e| {
+                NovaError::internal(format!(
+                    "Failed to parse plugin id from key '{}': {}",
+                    key_str, e
+                ))
+            })?;
+            Ok(parsed == plugin_id)
+        } else {
+            Ok(false)
+        }
+    }
+
+    fn context_key(context_id: &str, plugin_id: u64) -> Vec<u8> {
+        format!("{}|{}", context_id, plugin_id).into_bytes()
+    }
+
+    fn context_type_label(context_type: &PluginContextType) -> String {
+        match context_type {
+            PluginContextType::User => "user".to_string(),
+            PluginContextType::Group => "group".to_string(),
+        }
+    }
+}

--- a/src/plugins/mod.rs
+++ b/src/plugins/mod.rs
@@ -1,0 +1,15 @@
+pub mod dto;
+pub mod handler;
+mod helpers;
+pub mod manager;
+
+pub use dto::{
+    ErrorResponse, PluginContextType, PluginEnableRequest, PluginEnablementStatus,
+    PluginInvocationPayload, PluginInvocationRequest, PluginMetadata, PluginRegistrationRequest,
+    PluginUpdateRequest,
+};
+pub(crate) use handler::{
+    invoke_plugin, list_plugins, register_plugin, set_plugin_enablement, unregister_plugin,
+    update_plugin,
+};
+pub use manager::PluginManager;

--- a/src/server.rs
+++ b/src/server.rs
@@ -1,6 +1,7 @@
 use crate::config::NovaConfig;
 use crate::error::Result;
 use crate::mcp::dto::Tool;
+use crate::plugins::PluginManager;
 // Re-export MCP DTOs under `server` for backward compatibility
 pub use crate::mcp::dto::{McpError, McpRequest, McpResponse, ToolCall, ToolResult};
 use crate::tools::gecko_terminal::GeckoTerminalTools;
@@ -8,16 +9,18 @@ use crate::tools::new_pools::NewPoolsTools;
 use crate::tools::search_pools::SearchPoolsTools;
 use crate::tools::trending_pools::TrendingPoolsTools;
 use serde_json::json;
+use std::sync::Arc;
 
 pub struct NovaServer {
     gecko_terminal_tools: GeckoTerminalTools,
     trending_pools_tools: TrendingPoolsTools,
     search_pools_tools: SearchPoolsTools,
     new_pools_tools: NewPoolsTools,
+    plugin_manager: Arc<PluginManager>,
 }
 
 impl NovaServer {
-    pub fn new(_config: NovaConfig) -> Self {
+    pub fn new(_config: NovaConfig, plugin_manager: Arc<PluginManager>) -> Self {
         let gecko_terminal_tools = GeckoTerminalTools::new();
         let trending_pools_tools = TrendingPoolsTools::new();
         let search_pools_tools = SearchPoolsTools::new();
@@ -27,6 +30,7 @@ impl NovaServer {
             trending_pools_tools,
             search_pools_tools,
             new_pools_tools,
+            plugin_manager,
         }
     }
 
@@ -136,6 +140,14 @@ impl NovaServer {
         });
 
         tools
+    }
+
+    pub fn plugin_manager(&self) -> &PluginManager {
+        self.plugin_manager.as_ref()
+    }
+
+    pub fn plugin_manager_arc(&self) -> Arc<PluginManager> {
+        Arc::clone(&self.plugin_manager)
     }
 
     // handler logic is moved into crate::mcp::handler; keep server responsibilities focused

--- a/tests/invalid_tool_args.rs
+++ b/tests/invalid_tool_args.rs
@@ -1,10 +1,12 @@
 use nova_mcp::mcp::{dto::McpRequest, handler};
+use nova_mcp::plugins::PluginManager;
 use nova_mcp::{NovaConfig, NovaServer};
 use serde_json::json;
+use std::sync::Arc;
 
 #[tokio::test]
 async fn invalid_arguments_return_error() {
-    let server = NovaServer::new(NovaConfig::default());
+    let server = test_server();
     let req = McpRequest {
         jsonrpc: "2.0".to_string(),
         id: Some(json!(1)),
@@ -21,4 +23,13 @@ async fn invalid_arguments_return_error() {
     } else {
         panic!("expected error response");
     }
+}
+
+fn test_server() -> NovaServer {
+    let config = NovaConfig::default();
+    let db = sled::Config::new().temporary(true).open().unwrap();
+    let user_tree = db.open_tree("user_plugins").unwrap();
+    let group_tree = db.open_tree("group_plugins").unwrap();
+    let plugin_manager = Arc::new(PluginManager::new(user_tree, group_tree));
+    NovaServer::new(config, plugin_manager)
 }

--- a/tests/public_integration.rs
+++ b/tests/public_integration.rs
@@ -1,16 +1,27 @@
 // Integration tests that hit real public APIs. Marked ignored by default.
+use nova_mcp::plugins::PluginManager;
 use nova_mcp::server::ToolCall;
 use nova_mcp::{NovaConfig, NovaServer};
 use serde_json::json;
+use std::sync::Arc;
 
 #[tokio::test]
 #[ignore]
 async fn get_gecko_networks_live() {
-    let server = NovaServer::new(NovaConfig::default());
+    let server = test_server();
     let call = ToolCall {
         name: "get_gecko_networks".into(),
         arguments: json!({}),
     };
     let res = server.handle_tool_call(call).await.unwrap();
     assert!(res.content.contains("networks"));
+}
+
+fn test_server() -> NovaServer {
+    let config = NovaConfig::default();
+    let db = sled::Config::new().temporary(true).open().unwrap();
+    let user_tree = db.open_tree("user_plugins").unwrap();
+    let group_tree = db.open_tree("group_plugins").unwrap();
+    let plugin_manager = Arc::new(PluginManager::new(user_tree, group_tree));
+    NovaServer::new(config, plugin_manager)
 }


### PR DESCRIPTION
## Summary
- add a plugin module with DTOs, a Sled-backed PluginManager, and HTTP handlers for registering, listing, updating, invoking, and enabling plugins
- extend the HTTP server to share plugin state and expose unified plugin routes while reusing authentication and rate limiting
- initialize Sled in the server startup path, wire the PluginManager through NovaServer, and update examples/tests to build servers with the new storage

## Testing
- cargo check
- cargo test


------
https://chatgpt.com/codex/tasks/task_e_68c8352643748321b1cf4933b9ec6335