### PR TITLE
feat: add context-aware plugin platform

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -18,6 +18,20 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
+name = "ahash"
+version = "0.8.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5a15f179cd60c4584b8a8c596927aadc462e27f2ca70c04e0071964a73ba7a75"
+dependencies = [
+ "cfg-if",
+ "getrandom 0.3.3",
+ "once_cell",
+ "serde",
+ "version_check",
+ "zerocopy",
+]
+
+[[package]]
 name = "aho-corasick"
 version = "1.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -33,6 +47,56 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "819e7219dbd41043ac279b19830f2efc897156490d7fd6ea916720117ee66311"
 dependencies = [
  "libc",
+]
+
+[[package]]
+name = "anstream"
+version = "0.6.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3ae563653d1938f79b1ab1b5e668c87c76a9930414574a6583a7b7e11a8e6192"
+dependencies = [
+ "anstyle",
+ "anstyle-parse",
+ "anstyle-query",
+ "anstyle-wincon",
+ "colorchoice",
+ "is_terminal_polyfill",
+ "utf8parse",
+]
+
+[[package]]
+name = "anstyle"
+version = "1.0.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "862ed96ca487e809f1c8e5a8447f6ee2cf102f846893800b20cebdf541fc6bbd"
+
+[[package]]
+name = "anstyle-parse"
+version = "0.2.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4e7644824f0aa2c7b9384579234ef10eb7efb6a0deb83f9630a49594dd9c15c2"
+dependencies = [
+ "utf8parse",
+]
+
+[[package]]
+name = "anstyle-query"
+version = "1.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9e231f6134f61b71076a3eab506c379d4f36122f2af15a9ff04415ea4c3339e2"
+dependencies = [
+ "windows-sys 0.60.2",
+]
+
+[[package]]
+name = "anstyle-wincon"
+version = "3.0.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3e0633414522a32ffaac8ac6cc8f748e090c5717661fddeea04219e2344f5f2a"
+dependencies = [
+ "anstyle",
+ "once_cell_polyfill",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -163,6 +227,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9d297deb1925b89f2ccc13d7635fa0714f12c87adce1c75356b39ca9b7178567"
 
 [[package]]
+name = "bit-set"
+version = "0.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0700ddab506f33b20a03b13996eccd309a48e5ff77d0d95926aa0210fb4e95f1"
+dependencies = [
+ "bit-vec",
+]
+
+[[package]]
+name = "bit-vec"
+version = "0.6.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "349f9b6a179ed607305526ca489b34ad0a41aed5f7980fa90eb03160b69598fb"
+
+[[package]]
 name = "bitflags"
 version = "1.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -179,6 +258,12 @@ name = "bumpalo"
 version = "3.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "46c5e41b57b8bba42a04676d81cb89e9ee8e859a1a66f80a5a72e1cb76b34d43"
+
+[[package]]
+name = "bytecount"
+version = "0.6.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "175812e0be2bccb6abe50bb8d566126198344f707e304f45c648fd8f2cc0365e"
 
 [[package]]
 name = "byteorder"
@@ -223,6 +308,52 @@ dependencies = [
 ]
 
 [[package]]
+name = "clap"
+version = "4.5.47"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7eac00902d9d136acd712710d71823fb8ac8004ca445a89e73a41d45aa712931"
+dependencies = [
+ "clap_builder",
+ "clap_derive",
+]
+
+[[package]]
+name = "clap_builder"
+version = "4.5.47"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2ad9bbf750e73b5884fb8a211a9424a1906c1e156724260fdae972f31d70e1d6"
+dependencies = [
+ "anstream",
+ "anstyle",
+ "clap_lex",
+ "strsim",
+]
+
+[[package]]
+name = "clap_derive"
+version = "4.5.47"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bbfd7eae0b0f1a6e63d4b13c9c478de77c2eb546fba158ad50b4203dc24b9f9c"
+dependencies = [
+ "heck",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "clap_lex"
+version = "0.7.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b94f61472cee1439c0b966b47e3aca9ae07e45d070759512cd390ea2bebc6675"
+
+[[package]]
+name = "colorchoice"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b05b61dc5112cbb17e4b6cd61790d9845d13888356391624cbe7e41efeac1e75"
+
+[[package]]
 name = "core-foundation"
 version = "0.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -261,6 +392,15 @@ name = "crossbeam-utils"
 version = "0.8.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d0a5c400df2834b80a4c3327b3aad3a4c4cd4de0629063962b03235697506a28"
+
+[[package]]
+name = "deranged"
+version = "0.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d630bccd429a5bb5a64b5e94f693bfc48c9f8566418fda4c494cc94f911f87cc"
+dependencies = [
+ "powerfmt",
+]
 
 [[package]]
 name = "displaydoc"
@@ -305,6 +445,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "fancy-regex"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b95f7c0680e4142284cf8b22c14a476e87d61b004a3a0861872b32ef7ead40a2"
+dependencies = [
+ "bit-set",
+ "regex",
+]
+
+[[package]]
 name = "fastrand"
 version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -344,6 +494,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cb4cb245038516f5f85277875cdaa4f7d2c9a0fa0468de06ed190163b1581fcf"
 dependencies = [
  "percent-encoding",
+]
+
+[[package]]
+name = "fraction"
+version = "0.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3027ae1df8d41b4bed2241c8fdad4acc1e7af60c8e17743534b545e77182d678"
+dependencies = [
+ "lazy_static",
+ "num",
 ]
 
 [[package]]
@@ -415,6 +575,19 @@ dependencies = [
 
 [[package]]
 name = "getrandom"
+version = "0.2.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "335ff9f135e4384c8150d6f27c6daed433577f86b4750418338c01a1a2528592"
+dependencies = [
+ "cfg-if",
+ "js-sys",
+ "libc",
+ "wasi 0.11.1+wasi-snapshot-preview1",
+ "wasm-bindgen",
+]
+
+[[package]]
+name = "getrandom"
 version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "26145e563e54f2cadc477553f1ec5ee650b00862f0a58bcd12cbdc5f0ea2d2f4"
@@ -455,6 +628,12 @@ name = "hashbrown"
 version = "0.15.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9229cfe53dfd69f0609a49f65461bd93001ea1ef889cd5529dd176593f5338a1"
+
+[[package]]
+name = "heck"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
 
 [[package]]
 name = "http"
@@ -766,6 +945,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "469fb0b9cefa57e3ef31275ee7cacb78f2fdca44e4765491884a2b119d4eb130"
 
 [[package]]
+name = "is_terminal_polyfill"
+version = "1.70.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7943c866cc5cd64cbc25b2e01621d07fa8eb2a1a23160ee81ce38704e97b8ecf"
+
+[[package]]
+name = "iso8601"
+version = "0.6.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e1082f0c48f143442a1ac6122f67e360ceee130b967af4d50996e5154a45df46"
+dependencies = [
+ "nom",
+]
+
+[[package]]
 name = "itoa"
 version = "1.0.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -779,6 +973,36 @@ checksum = "0c0b063578492ceec17683ef2f8c5e89121fbd0b172cbc280635ab7567db2738"
 dependencies = [
  "once_cell",
  "wasm-bindgen",
+]
+
+[[package]]
+name = "jsonschema"
+version = "0.17.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2a071f4f7efc9a9118dfb627a0a94ef247986e1ab8606a4c806ae2b3aa3b6978"
+dependencies = [
+ "ahash",
+ "anyhow",
+ "base64",
+ "bytecount",
+ "clap",
+ "fancy-regex",
+ "fraction",
+ "getrandom 0.2.16",
+ "iso8601",
+ "itoa",
+ "memchr",
+ "num-cmp",
+ "once_cell",
+ "parking_lot 0.12.4",
+ "percent-encoding",
+ "regex",
+ "reqwest",
+ "serde",
+ "serde_json",
+ "time",
+ "url",
+ "uuid",
 ]
 
 [[package]]
@@ -892,6 +1116,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "nom"
+version = "8.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df9761775871bdef83bee530e60050f7e54b1105350d6884eb0fb4f46c2f9405"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
 name = "nova-mcp"
 version = "0.1.0"
 dependencies = [
@@ -900,6 +1133,7 @@ dependencies = [
  "chrono",
  "dotenvy",
  "hyper 1.7.0",
+ "jsonschema",
  "reqwest",
  "serde",
  "serde_json",
@@ -920,6 +1154,82 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d4a28e057d01f97e61255210fcff094d74ed0466038633e95017f5beb68e4399"
 dependencies = [
  "windows-sys 0.52.0",
+]
+
+[[package]]
+name = "num"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "35bd024e8b2ff75562e5f34e7f4905839deb4b22955ef5e73d2fea1b9813cb23"
+dependencies = [
+ "num-bigint",
+ "num-complex",
+ "num-integer",
+ "num-iter",
+ "num-rational",
+ "num-traits",
+]
+
+[[package]]
+name = "num-bigint"
+version = "0.4.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a5e44f723f1133c9deac646763579fdb3ac745e418f2a7af9cd0c431da1f20b9"
+dependencies = [
+ "num-integer",
+ "num-traits",
+]
+
+[[package]]
+name = "num-cmp"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "63335b2e2c34fae2fb0aa2cecfd9f0832a1e24b3b32ecec612c3426d46dc8aaa"
+
+[[package]]
+name = "num-complex"
+version = "0.4.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "73f88a1307638156682bada9d7604135552957b7818057dcef22705b4d509495"
+dependencies = [
+ "num-traits",
+]
+
+[[package]]
+name = "num-conv"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "51d515d32fb182ee37cda2ccdcb92950d6a3c2893aa280e540671c2cd0f3b1d9"
+
+[[package]]
+name = "num-integer"
+version = "0.1.46"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7969661fd2958a5cb096e56c8e1ad0444ac2bbcd0061bd28660485a44879858f"
+dependencies = [
+ "num-traits",
+]
+
+[[package]]
+name = "num-iter"
+version = "0.1.45"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1429034a0490724d0075ebb2bc9e875d6503c3cf69e235a8941aa757d83ef5bf"
+dependencies = [
+ "autocfg",
+ "num-integer",
+ "num-traits",
+]
+
+[[package]]
+name = "num-rational"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f83d14da390562dca69fc84082e73e548e1ad308d24accdedd2720017cb37824"
+dependencies = [
+ "num-bigint",
+ "num-integer",
+ "num-traits",
 ]
 
 [[package]]
@@ -945,6 +1255,12 @@ name = "once_cell"
 version = "1.21.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "42f5e15c9953c5e4ccceeb2e7382a716482c34515315f7b03532b8b4e8393d2d"
+
+[[package]]
+name = "once_cell_polyfill"
+version = "1.70.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a4895175b425cb1f87721b59f0f286c2092bd4af812243672510e1ac53e2e0ad"
 
 [[package]]
 name = "openssl"
@@ -1072,6 +1388,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "powerfmt"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "439ee305def115ba05938db6eb1644ff94165c5ab5e9420d1c1bcedbba909391"
+
+[[package]]
 name = "proc-macro2"
 version = "1.0.101"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1111,6 +1433,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5407465600fb0548f1442edf71dd20683c6ed326200ace4b1ef0763521bb3b77"
 dependencies = [
  "bitflags 2.9.4",
+]
+
+[[package]]
+name = "regex"
+version = "1.11.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "23d7fd106d8c02486a8d64e778353d1cffe08ce79ac2e82f540c86d0facf6912"
+dependencies = [
+ "aho-corasick",
+ "memchr",
+ "regex-automata",
+ "regex-syntax",
 ]
 
 [[package]]
@@ -1391,6 +1725,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a8f112729512f8e442d81f95a8a7ddf2b7c6b8a1a6f509a95864142b30cab2d3"
 
 [[package]]
+name = "strsim"
+version = "0.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
+
+[[package]]
 name = "syn"
 version = "2.0.106"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1452,7 +1792,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "15b61f8f20e3a6f7e0649d825294eaf317edce30f82cf6026e7e4cb9222a7d1e"
 dependencies = [
  "fastrand",
- "getrandom",
+ "getrandom 0.3.3",
  "once_cell",
  "rustix",
  "windows-sys 0.60.2",
@@ -1485,6 +1825,36 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f60246a4944f24f6e018aa17cdeffb7818b76356965d03b07d6a9886e8962185"
 dependencies = [
  "cfg-if",
+]
+
+[[package]]
+name = "time"
+version = "0.3.43"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "83bde6f1ec10e72d583d91623c939f623002284ef622b87de38cfd546cbf2031"
+dependencies = [
+ "deranged",
+ "num-conv",
+ "powerfmt",
+ "serde",
+ "time-core",
+ "time-macros",
+]
+
+[[package]]
+name = "time-core"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "40868e7c1d2f0b8d73e4a8c7f0ff63af4f6d19be117e90bd73eb1d62cf831c6b"
+
+[[package]]
+name = "time-macros"
+version = "0.2.24"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "30cfb0125f12d9c277f35663a0a33f8c30190f4e4574868a330595412d34ebf3"
+dependencies = [
+ "num-conv",
+ "time-core",
 ]
 
 [[package]]
@@ -1743,6 +2113,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6c140620e7ffbb22c2dee59cafe6084a59b5ffc27a8859a5f0d494b5d52b6be"
 
 [[package]]
+name = "utf8parse"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
+
+[[package]]
+name = "uuid"
+version = "1.18.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2f87b8aa10b915a06587d0dec516c282ff295b475d94abf425d62b57710070a2"
+dependencies = [
+ "js-sys",
+ "wasm-bindgen",
+]
+
+[[package]]
 name = "valuable"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1753,6 +2139,12 @@ name = "vcpkg"
 version = "0.2.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "accd4ea62f7bb7a82fe23066fb0957d48ef677f6eeb8215f372f52e48bb32426"
+
+[[package]]
+name = "version_check"
+version = "0.9.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
 
 [[package]]
 name = "want"
@@ -2231,6 +2623,26 @@ dependencies = [
  "quote",
  "syn",
  "synstructure",
+]
+
+[[package]]
+name = "zerocopy"
+version = "0.8.27"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0894878a5fa3edfd6da3f88c4805f4c8558e2b996227a3d864f47fe11e38282c"
+dependencies = [
+ "zerocopy-derive",
+]
+
+[[package]]
+name = "zerocopy-derive"
+version = "0.8.27"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "88d2b8d9c68ad2b9e4340d7832716a4d21a22a1154777ad56ea55c51a9cf3831"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,6 +34,9 @@ thiserror = "1.0"
 # Storage
 sled = "0.34"
 
+# JSON Schema validation
+jsonschema = "0.17"
+
 # Logging
 tracing = "0.1"
 tracing-subscriber = { version = "0.3", features = ["env-filter"] }

--- a/documentation.md
+++ b/documentation.md
@@ -158,5 +158,175 @@ TOML config (`config.toml`) mirrors `NovaConfig` (see README for example). You c
 
 - “Unauthorized” on HTTP: Make sure `NOVA_MCP_AUTH_ENABLED=true` and include the header (`x-api-key: your_key`).
 - Rate limit exceeded: Increase `rate_limit_per_minute` or reduce request frequency.
+
+## Nova-MCP Upgrade Plan – User & Group Context
+
+### 1. Introduction and Scope
+
+Nova-MCP currently exposes a fixed set of GeckoTerminal tools through the Model Context Protocol (MCP) and offers a basic plugin registry that stores HTTP endpoints. This upgrade introduces multi-tenant tooling by associating every tool with a **context**—either an individual user or a Telegram group. Requests are still authenticated with a single API key, while the caller identity is derived from the `(context_type, context_id)` pair supplied with each request. The plan below supersedes earlier drafts by clarifying context handling and simplifying authentication.
+
+### 2. Current Architecture Summary
+
+- Built-in tools are defined by `Tool { name, description, input_schema }` structs and assembled in `NovaServer::get_tools()`.
+- Plugins are registered with `/plugins/register` via `PluginRegistrationRequest` (fields: `name`, `description`, `owner_id`, `scopes`, `endpoint`, `trust_level`).
+- Plugins can be enabled per user or per group through `PluginEnableRequest`, which carries `context_type` (`User` or `Group`) and `context_id`.
+- Authentication uses a single API key configured via environment variables to guard the HTTP API.
+
+### 3. Revised Requirements
+
+1. **User and Group Context** – Tools are owned by `(context_type, context_id)` pairs. The values are stored with each tool and used for filtering.
+2. **Single API Key** – All HTTP requests share one API key. Each request must also include the caller context headers.
+3. **Web Dashboard** – Provide a browser UI for defining schemas, registering tools, managing enablement, and generating implementation stubs per context.
+4. **Backward Compatibility** – Built-in tools and the existing plugin registry continue to function without breaking current clients.
+5. **Security and Isolation** – Tools run as external services. Nova validates inputs against declared schemas and ensures enablement matches the request context.
+
+### 4. Data Model Changes
+
+#### 4.1 Tool Ownership
+
+Extend `PluginRegistrationRequest` (and related structs) with:
+
+| Field          | Type                     | Description                                                                 |
+| -------------- | ------------------------ | --------------------------------------------------------------------------- |
+| `context_type` | `PluginContextType`      | Either `User` or `Group`; identifies personal vs. group ownership.          |
+| `context_id`   | `String`                 | Telegram user ID or group ID used to scope the tool.                        |
+| `input_schema` | `serde_json::Value`      | JSON schema for tool arguments.                                             |
+| `output_schema`| `Option<serde_json::Value>` | Optional JSON schema describing the result payload.                      |
+| `version`      | `u32`                    | Tool definition version number.                                             |
+
+During registration the server validates that `context_type` and `context_id` match Telegram semantics (e.g., group IDs are negative). The existing `owner_id` remains available for internal references.
+
+#### 4.2 Tool Namespacing
+
+Fully qualified tool names prevent collisions:
+
+```rust
+if context_type == User {
+    fq_name = format!("user_{}_{}_v{}", context_id, name, version);
+} else {
+    fq_name = format!("group_{}_{}_v{}", context_id, name, version);
+}
+```
+
+The `tools/list` response returns this fully qualified name. Descriptions continue to display friendly names and ownership details.
+
+### 5. API and Protocol Changes
+
+#### 5.1 Context Identification
+
+- **HTTP headers** – Require `x-api-key`, `x-nova-context-type`, and `x-nova-context-id` on every call.
+- **JSON-RPC (stdio)** – Add optional root-level `context_type` and `context_id` fields; reject user-defined tool calls when missing.
+- **Middleware** – Extract context values and pass them to listing/invocation logic. Invalid or missing values return authentication errors.
+
+#### 5.2 Tool Registration
+
+Introduce `/tools/register` that:
+
+1. Validates request headers against body context, checks schema shapes, and prevents intra-context name conflicts.
+2. Persists metadata (`PluginMetadata`) including schemas, computes the fully qualified name, and assigns `plugin_id`.
+3. Automatically enables the tool for its owning context.
+4. Returns the `plugin_id`, fully qualified name, and version.
+
+`PUT /tools/:plugin_id` follows the same rules, incrementing `version`. Older versions remain accessible for compatibility.
+
+#### 5.3 Tool Listing
+
+`tools/list` now:
+
+1. Extracts the caller context.
+2. Loads built-in tools as before.
+3. Queries the plugin manager for enabled plugins matching the caller context.
+4. Converts each plugin to a `Tool` using the fully qualified name and stored schemas.
+5. Returns the combined list.
+
+#### 5.4 Tool Invocation
+
+When `tools/call` is invoked:
+
+1. Dispatch built-in tools normally when names match.
+2. Otherwise parse the fully qualified name into `(context_type, context_id, base_name, version)`.
+3. Verify the caller context matches the parsed context.
+4. Confirm the tool is enabled for the caller.
+5. Validate arguments against `input_schema`.
+6. Invoke the plugin endpoint with `PluginInvocationRequest { context_type, context_id, arguments }` and validate responses against `output_schema` (when provided).
+
+#### 5.5 Other Plugin Endpoints
+
+Keep existing `/plugins/*` endpoints for admin workflows. `/tools/*` becomes the primary user surface.
+
+### 6. Server Implementation Changes
+
+#### 6.1 Auth Middleware
+
+- Parse `x-nova-context-type` and `x-nova-context-id` alongside `x-api-key`.
+- Validate type/value combinations (e.g., numeric IDs, negative group IDs) and store them in request context.
+
+#### 6.2 Plugin Manager
+
+- Extend `PluginMetadata` with context, schema, and version fields.
+- Add helpers such as `list_plugins_for_context` and `get_plugin_by_fq_name`.
+- Support versioning by storing multiple versions per `(context_type, context_id, base_name)` and defaulting to the highest.
+- Automatically record enablement for the owner context at registration time.
+
+#### 6.3 MCP Handlers
+
+- Update `NovaServer::get_tools()` to accept context, merge built-in tools with context-filtered plugins, and return the aggregated list.
+- Update `handle_tool_call()` to parse fully qualified names, enforce context checks, and route invocations through the plugin manager.
+
+### 7. Web Dashboard
+
+#### 7.1 Authentication
+
+- Prompt for API key and user/group ID, store them in session memory, and include them in every request.
+- Display the active context and allow quick switching between personal and group scopes.
+
+#### 7.2 Tool Creation Workflow
+
+1. Select context (auto-detect groups via negative IDs).
+2. Define tool metadata (name, description) with per-context uniqueness.
+3. Build input schema using guided helpers and inline validation.
+4. (Optional) Define an output schema.
+5. Provide implementation details (HTTPS endpoint or generated stub) with expectations for JSON POST payloads/responses.
+6. Register via `/tools/register` and surface the fully qualified tool name.
+7. Optionally enable the tool for additional contexts using `/plugins/enable`.
+
+#### 7.3 Manage Tools
+
+- List tools for the current context with base name, version, status, and creation date.
+- Support enabling/disabling, editing (with version bumps), deletion, and cross-context enablement.
+- (Optional) Display invocation logs for diagnostics.
+
+#### 7.4 Implementation Notes
+
+- Build as a React SPA served by Nova or standalone with configurable API base URL.
+- Use validated forms (e.g., React Hook Form) and provide a JSON editor for advanced schema editing.
+- Editing a tool clones metadata, increments the version, and publishes the new definition as the default in `tools/list`.
+
+### 8. Security and Governance
+
+- Implement per-context rate limiting (registrations and invocations).
+- Sanitize schemas to allow only safe JSON Schema keywords.
+- Enforce ownership rules—only the owning context can update/delete; group admins may receive elevated rights via existing management features.
+- Record audit logs with actor, timestamp, context, and IP metadata. Provide an admin route to inspect logs.
+- Keep the design extensible for future context types.
+
+### 9. Testing
+
+- Unit tests: context parsing, name formatting, plugin filtering.
+- Integration tests: registration/listing/invocation flows, context mismatch handling.
+- UI tests: dashboard context selection and management workflows.
+
+### 10. Roll-out Plan
+
+1. **Design Review** – Validate context model and Telegram ID compatibility.
+2. **Back-End Implementation (~3 weeks)** – Update plugin manager, auth layer, tool registration, and MCP handlers; add endpoints and versioning.
+3. **Dashboard Implementation (~3–4 weeks)** – Build/update UI for context workflows.
+4. **Testing & QA (2 weeks)** – Verify context isolation and regression coverage for built-in tools.
+5. **Documentation & Communication (1 week)** – Update README/docs and provide usage examples.
+6. **Deployment** – Stage, migrate plugin data to include context fields, release to production, and monitor logs for misconfigured contexts.
+
+### 11. Conclusion
+
+By anchoring every tool to a `(context_type, context_id)` pair, Nova-MCP becomes a multi-tenant platform while retaining the simplicity of a single API key. The web dashboard empowers individuals and groups to build, test, and manage their tools, and the back end enforces validation, versioning, and context isolation for a safe ecosystem.
 - Live API flakiness: GeckoTerminal is public; expect occasional rate limits or transient errors; retry or add caching if needed.
 

--- a/examples/test_client.rs
+++ b/examples/test_client.rs
@@ -12,7 +12,7 @@ async fn main() -> Result<()> {
 
     let server = build_server()?;
     println!("Available tools:");
-    for t in server.get_tools() {
+    for t in server.get_tools(None) {
         println!(" - {}: {}", t.name, t.description);
     }
 
@@ -22,7 +22,7 @@ async fn main() -> Result<()> {
     };
     println!(
         "gecko_networks -> {:?}",
-        server.handle_tool_call(networks).await?.content
+        server.handle_tool_call(networks, None).await?.content
     );
 
     let trending = ToolCall {
@@ -31,7 +31,7 @@ async fn main() -> Result<()> {
     };
     println!(
         "trending_pools -> {:?}",
-        server.handle_tool_call(trending).await?.content
+        server.handle_tool_call(trending, None).await?.content
     );
     Ok(())
 }

--- a/src/context/dto.rs
+++ b/src/context/dto.rs
@@ -1,0 +1,9 @@
+use serde::{Deserialize, Serialize};
+
+use crate::plugins::PluginContextType;
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct RequestContext {
+    pub context_type: PluginContextType,
+    pub context_id: String,
+}

--- a/src/context/helpers.rs
+++ b/src/context/helpers.rs
@@ -1,0 +1,128 @@
+use axum::http::HeaderMap;
+use serde_json::Value;
+
+use crate::error::NovaError;
+use crate::plugins::PluginContextType;
+
+use super::dto::RequestContext;
+
+const HEADER_CONTEXT_TYPE: &str = "x-nova-context-type";
+const HEADER_CONTEXT_ID: &str = "x-nova-context-id";
+
+pub fn extract_context_from_headers(
+    headers: &HeaderMap,
+) -> Result<Option<RequestContext>, NovaError> {
+    let context_type = headers
+        .get(HEADER_CONTEXT_TYPE)
+        .map(|value| value.to_str().map(|s| s.trim().to_string()));
+    let context_id = headers
+        .get(HEADER_CONTEXT_ID)
+        .map(|value| value.to_str().map(|s| s.trim().to_string()));
+
+    match (context_type, context_id) {
+        (None, None) => Ok(None),
+        (Some(Ok(context_type)), Some(Ok(context_id))) => {
+            let parsed_type = parse_context_type(&context_type)?;
+            validate_context_pair(&parsed_type, &context_id)?;
+            Ok(Some(RequestContext {
+                context_type: parsed_type,
+                context_id,
+            }))
+        }
+        (Some(Err(_)), _) | (_, Some(Err(_))) => Err(NovaError::validation_error(
+            "Invalid UTF-8 in context headers",
+        )),
+        _ => Err(NovaError::validation_error(
+            "Both x-nova-context-type and x-nova-context-id are required",
+        )),
+    }
+}
+
+pub fn extract_context_from_value(value: &Value) -> Result<Option<RequestContext>, NovaError> {
+    let context_type = value.get("context_type");
+    let context_id = value.get("context_id");
+
+    match (context_type, context_id) {
+        (None, None) => Ok(None),
+        (Some(Value::String(context_type)), Some(Value::String(context_id))) => {
+            let parsed_type = parse_context_type(context_type)?;
+            validate_context_pair(&parsed_type, context_id)?;
+            Ok(Some(RequestContext {
+                context_type: parsed_type,
+                context_id: context_id.clone(),
+            }))
+        }
+        _ => Err(NovaError::validation_error(
+            "context_type and context_id must be strings when provided",
+        )),
+    }
+}
+
+pub fn require_matching_context(
+    expected: &RequestContext,
+    supplied: &RequestContext,
+) -> Result<(), NovaError> {
+    if expected.context_type != supplied.context_type || expected.context_id != supplied.context_id
+    {
+        Err(NovaError::validation_error(
+            "Context mismatch between caller and tool",
+        ))
+    } else {
+        Ok(())
+    }
+}
+
+pub fn context_key_for_rate_limit(context: Option<&RequestContext>, fallback_key: &str) -> String {
+    match context {
+        Some(ctx) => match ctx.context_type {
+            PluginContextType::User => format!("user:{}", ctx.context_id),
+            PluginContextType::Group => format!("group:{}", ctx.context_id),
+        },
+        None => format!("api:{}", fallback_key),
+    }
+}
+
+pub fn parse_context_type(value: &str) -> Result<PluginContextType, NovaError> {
+    match value.to_lowercase().as_str() {
+        "user" => Ok(PluginContextType::User),
+        "group" => Ok(PluginContextType::Group),
+        other => Err(NovaError::validation_error(format!(
+            "Unknown context type: {}",
+            other
+        ))),
+    }
+}
+
+pub fn validate_context_pair(
+    context_type: &PluginContextType,
+    context_id: &str,
+) -> Result<(), NovaError> {
+    if context_id.trim().is_empty() {
+        return Err(NovaError::validation_error("context_id cannot be empty"));
+    }
+
+    if context_id.parse::<i64>().is_err() {
+        return Err(NovaError::validation_error(
+            "context_id must be a numeric string",
+        ));
+    }
+
+    match context_type {
+        PluginContextType::User => {
+            if context_id.starts_with('-') {
+                return Err(NovaError::validation_error(
+                    "User context IDs must be positive",
+                ));
+            }
+        }
+        PluginContextType::Group => {
+            if !context_id.starts_with('-') {
+                return Err(NovaError::validation_error(
+                    "Group context IDs must be negative",
+                ));
+            }
+        }
+    }
+
+    Ok(())
+}

--- a/src/context/mod.rs
+++ b/src/context/mod.rs
@@ -1,0 +1,10 @@
+pub mod dto;
+mod helpers;
+mod request_context;
+
+pub use dto::RequestContext;
+pub use helpers::{
+    context_key_for_rate_limit, extract_context_from_headers, extract_context_from_value,
+    parse_context_type, require_matching_context, validate_context_pair,
+};
+pub use request_context::RequestContextExt;

--- a/src/context/request_context.rs
+++ b/src/context/request_context.rs
@@ -1,0 +1,30 @@
+use super::dto::RequestContext;
+
+pub trait RequestContextExt {
+    fn rate_limit_key(&self) -> String;
+    fn label(&self) -> String;
+}
+
+impl RequestContextExt for RequestContext {
+    fn rate_limit_key(&self) -> String {
+        match self.context_type {
+            crate::plugins::PluginContextType::User => {
+                format!("user:{}", self.context_id)
+            }
+            crate::plugins::PluginContextType::Group => {
+                format!("group:{}", self.context_id)
+            }
+        }
+    }
+
+    fn label(&self) -> String {
+        match self.context_type {
+            crate::plugins::PluginContextType::User => {
+                format!("User {}", self.context_id)
+            }
+            crate::plugins::PluginContextType::Group => {
+                format!("Group {}", self.context_id)
+            }
+        }
+    }
+}

--- a/src/http.rs
+++ b/src/http.rs
@@ -1,3 +1,4 @@
+use crate::context::{context_key_for_rate_limit, extract_context_from_headers};
 use crate::mcp::dto::{McpRequest, McpResponse};
 use crate::plugins::{self, PluginManager};
 use crate::{ApiKeyAuth, NovaConfig, NovaServer};
@@ -5,7 +6,7 @@ use anyhow::Result;
 use axum::{
     extract::DefaultBodyLimit,
     http::StatusCode,
-    routing::{delete, get, post},
+    routing::{delete, get, post, put},
     Json, Router,
 };
 use std::collections::HashMap;
@@ -65,9 +66,28 @@ async fn handle_rpc(
         };
         return Json(res);
     }
-    // Simple per-key rate limiting
-    let key = presented.unwrap_or("anonymous").to_string();
-    if let Some(code) = check_rate_limit(&state, &key).await {
+    let api_key = presented.unwrap_or("anonymous").to_string();
+
+    let context = match extract_context_from_headers(&headers) {
+        Ok(ctx) => ctx,
+        Err(err) => {
+            let res = McpResponse {
+                jsonrpc: "2.0".to_string(),
+                id: None,
+                result: None,
+                error: Some(crate::mcp::dto::McpError {
+                    code: StatusCode::BAD_REQUEST.as_u16() as i32,
+                    message: err.to_string(),
+                    data: None,
+                }),
+            };
+            return Json(res);
+        }
+    };
+
+    let rate_key = context_key_for_rate_limit(context.as_ref(), &api_key);
+
+    if let Some(code) = check_rate_limit(&state, &rate_key).await {
         let res = McpResponse {
             jsonrpc: "2.0".to_string(),
             id: None,
@@ -81,7 +101,7 @@ async fn handle_rpc(
         return Json(res);
     }
     let server = state.server();
-    let res = crate::mcp::handler::handle_request(server.as_ref(), req).await;
+    let res = crate::mcp::handler::handle_request(server.as_ref(), req, context).await;
     Json(res)
 }
 
@@ -116,6 +136,9 @@ pub async fn run_http_server(server: NovaServer, config: NovaConfig) -> Result<(
         .route("/plugins", get(plugins::list_plugins))
         .route("/plugins/:plugin_id/call", post(plugins::invoke_plugin))
         .route("/plugins/enable", post(plugins::set_plugin_enablement))
+        .route("/tools/register", post(plugins::register_tool))
+        .route("/tools/:plugin_id", put(plugins::update_tool))
+        .route("/tools", get(plugins::list_tools))
         .layer(DefaultBodyLimit::max(1024 * 1024))
         .with_state(state);
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,5 +1,6 @@
 pub mod auth;
 pub mod config;
+pub mod context;
 pub mod error;
 pub mod http;
 pub mod mcp;

--- a/src/main.rs
+++ b/src/main.rs
@@ -48,8 +48,8 @@ async fn main() -> Result<()> {
     // Create server instance
     let server = NovaServer::new(config.clone(), Arc::clone(&plugin_manager));
 
-    tracing::info!("Available tools: {}", server.get_tools().len());
-    for tool in server.get_tools() {
+    tracing::info!("Available tools: {}", server.get_tools(None).len());
+    for tool in server.get_tools(None) {
         tracing::info!("  - {}: {}", tool.name, tool.description);
     }
 
@@ -85,7 +85,8 @@ async fn main() -> Result<()> {
 
                         match serde_json::from_str::<McpRequest>(line) {
                             Ok(request) => {
-                                let response = handler::handle_request(&server, request).await;
+                                let response =
+                                    handler::handle_request(&server, request, None).await;
                                 let response_json = serde_json::to_string(&response)?;
 
                                 tracing::debug!("Sending: {}", response_json);

--- a/src/mcp/dto.rs
+++ b/src/mcp/dto.rs
@@ -26,6 +26,10 @@ pub struct McpRequest {
     pub id: Option<Value>,
     pub method: String,
     pub params: Option<Value>,
+    #[serde(default)]
+    pub context_type: Option<String>,
+    #[serde(default)]
+    pub context_id: Option<String>,
 }
 
 #[derive(Debug, Serialize, Deserialize)]

--- a/src/mcp/handler.rs
+++ b/src/mcp/handler.rs
@@ -1,3 +1,7 @@
+use crate::context::{
+    parse_context_type, require_matching_context, validate_context_pair, RequestContext,
+};
+use crate::plugins::{PluginInvocationRequest, PluginManager};
 use crate::server::NovaServer;
 use crate::{
     error::NovaError,
@@ -13,10 +17,34 @@ use serde_json::json;
 
 use super::dto::{McpError, McpRequest, McpResponse, ToolCall, ToolResult};
 
-pub async fn handle_request(server: &NovaServer, request: McpRequest) -> McpResponse {
+pub async fn handle_request(
+    server: &NovaServer,
+    request: McpRequest,
+    context_override: Option<RequestContext>,
+) -> McpResponse {
+    let context = match resolve_context(
+        request.context_type.as_deref(),
+        request.context_id.as_deref(),
+        context_override,
+    ) {
+        Ok(ctx) => ctx,
+        Err(err) => {
+            return McpResponse {
+                jsonrpc: "2.0".to_string(),
+                id: request.id,
+                result: None,
+                error: Some(McpError {
+                    code: -32602,
+                    message: err.to_string(),
+                    data: None,
+                }),
+            };
+        }
+    };
+
     match request.method.as_str() {
         "tools/list" => {
-            let tools = server.get_tools();
+            let tools = server.get_tools(context.as_ref());
             McpResponse {
                 jsonrpc: "2.0".to_string(),
                 id: request.id,
@@ -29,7 +57,7 @@ pub async fn handle_request(server: &NovaServer, request: McpRequest) -> McpResp
         "tools/call" => {
             if let Some(params) = request.params {
                 if let Ok(tool_call) = serde_json::from_value::<ToolCall>(params) {
-                    match handle_tool_call(server, tool_call).await {
+                    match handle_tool_call(server, tool_call, context.as_ref()).await {
                         Ok(result) => McpResponse {
                             jsonrpc: "2.0".to_string(),
                             id: request.id,
@@ -53,28 +81,10 @@ pub async fn handle_request(server: &NovaServer, request: McpRequest) -> McpResp
                         },
                     }
                 } else {
-                    McpResponse {
-                        jsonrpc: "2.0".to_string(),
-                        id: request.id,
-                        result: None,
-                        error: Some(McpError {
-                            code: -32602,
-                            message: "Invalid tool call parameters".to_string(),
-                            data: None,
-                        }),
-                    }
+                    invalid_params(request.id, "Invalid tool call parameters")
                 }
             } else {
-                McpResponse {
-                    jsonrpc: "2.0".to_string(),
-                    id: request.id,
-                    result: None,
-                    error: Some(McpError {
-                        code: -32602,
-                        message: "Missing parameters".to_string(),
-                        data: None,
-                    }),
-                }
+                invalid_params(request.id, "Missing parameters")
             }
         }
         "initialize" => McpResponse {
@@ -109,6 +119,7 @@ pub async fn handle_request(server: &NovaServer, request: McpRequest) -> McpResp
 pub(crate) async fn handle_tool_call(
     server: &NovaServer,
     tool_call: ToolCall,
+    context: Option<&RequestContext>,
 ) -> Result<ToolResult, NovaError> {
     tracing::info!("Handling tool call: {}", tool_call.name);
     let result = match tool_call.name.as_str() {
@@ -175,16 +186,85 @@ pub(crate) async fn handle_tool_call(
             let output = get_new_pools(server.new_pools_tools(), input).await?;
             serde_json::to_value(output)?
         }
-        _ => {
-            return Err(NovaError::api_error(format!(
-                "Unknown tool: {}",
-                tool_call.name
-            )));
-        }
+        _ => handle_plugin_tool_call(server.plugin_manager(), tool_call, context).await?,
     };
 
     Ok(ToolResult {
         content: serde_json::to_string_pretty(&result)?,
         is_error: false,
     })
+}
+
+async fn handle_plugin_tool_call(
+    manager: &PluginManager,
+    tool_call: ToolCall,
+    context: Option<&RequestContext>,
+) -> Result<serde_json::Value, NovaError> {
+    let caller_context = context.ok_or_else(|| {
+        NovaError::validation_error("Context headers are required for custom tools")
+    })?;
+
+    let metadata = manager.get_plugin_by_fq_name(&tool_call.name)?;
+
+    let plugin_context_type = metadata
+        .context_type
+        .clone()
+        .ok_or_else(|| NovaError::validation_error("Plugin missing context type"))?;
+    let plugin_context_id = metadata
+        .context_id
+        .clone()
+        .ok_or_else(|| NovaError::validation_error("Plugin missing context id"))?;
+
+    let plugin_context = RequestContext {
+        context_type: plugin_context_type,
+        context_id: plugin_context_id,
+    };
+
+    require_matching_context(&plugin_context, caller_context)?;
+
+    let invocation = PluginInvocationRequest {
+        context_type: caller_context.context_type.clone(),
+        context_id: caller_context.context_id.clone(),
+        arguments: tool_call.arguments,
+    };
+
+    manager.invoke_plugin(metadata.plugin_id, invocation).await
+}
+
+fn invalid_params(id: Option<serde_json::Value>, message: &str) -> McpResponse {
+    McpResponse {
+        jsonrpc: "2.0".to_string(),
+        id,
+        result: None,
+        error: Some(McpError {
+            code: -32602,
+            message: message.to_string(),
+            data: None,
+        }),
+    }
+}
+
+fn resolve_context(
+    context_type: Option<&str>,
+    context_id: Option<&str>,
+    override_context: Option<RequestContext>,
+) -> Result<Option<RequestContext>, NovaError> {
+    if override_context.is_some() {
+        return Ok(override_context);
+    }
+
+    match (context_type, context_id) {
+        (Some(context_type), Some(context_id)) => {
+            let parsed = parse_context_type(context_type)?;
+            validate_context_pair(&parsed, context_id)?;
+            Ok(Some(RequestContext {
+                context_type: parsed,
+                context_id: context_id.to_string(),
+            }))
+        }
+        (None, None) => Ok(None),
+        _ => Err(NovaError::validation_error(
+            "Both context_type and context_id are required",
+        )),
+    }
 }

--- a/src/plugins/dto.rs
+++ b/src/plugins/dto.rs
@@ -1,4 +1,5 @@
 use serde::{Deserialize, Serialize};
+use serde_json::Value;
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct PluginRegistrationRequest {
@@ -10,6 +11,16 @@ pub struct PluginRegistrationRequest {
     #[serde(default)]
     pub icon_url: Option<String>,
     pub trust_level: String,
+    #[serde(default)]
+    pub context_type: Option<PluginContextType>,
+    #[serde(default)]
+    pub context_id: Option<String>,
+    #[serde(default)]
+    pub input_schema: Option<Value>,
+    #[serde(default)]
+    pub output_schema: Option<Value>,
+    #[serde(default)]
+    pub version: Option<u32>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -23,6 +34,18 @@ pub struct PluginMetadata {
     #[serde(default)]
     pub icon_url: Option<String>,
     pub trust_level: String,
+    #[serde(default)]
+    pub context_type: Option<PluginContextType>,
+    #[serde(default)]
+    pub context_id: Option<String>,
+    #[serde(default)]
+    pub input_schema: Option<Value>,
+    #[serde(default)]
+    pub output_schema: Option<Value>,
+    #[serde(default = "default_version")]
+    pub version: u32,
+    #[serde(default)]
+    pub fully_qualified_name: Option<String>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, Default)]
@@ -41,6 +64,35 @@ pub struct PluginUpdateRequest {
     pub icon_url: Option<Option<String>>,
     #[serde(default)]
     pub trust_level: Option<String>,
+    #[serde(default)]
+    pub input_schema: Option<Option<Value>>,
+    #[serde(default)]
+    pub output_schema: Option<Option<Value>>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, Default)]
+pub struct ToolUpdateRequest {
+    #[serde(default)]
+    pub name: Option<String>,
+    #[serde(default)]
+    pub description: Option<String>,
+    #[serde(default)]
+    pub endpoint: Option<String>,
+    #[serde(default)]
+    pub input_schema: Option<Value>,
+    #[serde(default)]
+    pub output_schema: Option<Option<Value>>,
+    #[serde(default)]
+    pub icon_url: Option<Option<String>>,
+    #[serde(default)]
+    pub trust_level: Option<String>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ToolRegistrationResponse {
+    pub plugin_id: u64,
+    pub fully_qualified_name: String,
+    pub version: u32,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
@@ -55,14 +107,14 @@ pub struct PluginInvocationRequest {
     pub context_type: PluginContextType,
     pub context_id: String,
     #[serde(default)]
-    pub arguments: serde_json::Value,
+    pub arguments: Value,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct PluginInvocationPayload {
     pub context_type: PluginContextType,
     pub context_id: String,
-    pub arguments: serde_json::Value,
+    pub arguments: Value,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -105,4 +157,8 @@ pub struct GroupPluginRecord {
     #[serde(default)]
     pub added_by: Option<String>,
     pub consent_ts: i64,
+}
+
+fn default_version() -> u32 {
+    1
 }

--- a/src/plugins/manager.rs
+++ b/src/plugins/manager.rs
@@ -4,18 +4,22 @@ use std::sync::atomic::{AtomicU64, Ordering};
 use std::sync::RwLock;
 
 use chrono::Utc;
+use jsonschema::JSONSchema;
 use reqwest::Client;
+use serde_json::Value;
 
+use crate::context::{require_matching_context, validate_context_pair, RequestContext};
 use crate::error::{NovaError, Result};
 
 use super::dto::{
     GroupPluginRecord, PluginContextType, PluginEnableRequest, PluginEnablementStatus,
     PluginInvocationPayload, PluginInvocationRequest, PluginMetadata, PluginRegistrationRequest,
-    PluginUpdateRequest, UserPluginRecord,
+    PluginUpdateRequest, ToolRegistrationResponse, ToolUpdateRequest, UserPluginRecord,
 };
 
 pub struct PluginManager {
     plugins: RwLock<HashMap<u64, PluginMetadata>>,
+    historical_plugins: RwLock<HashMap<String, PluginMetadata>>,
     user_tree: sled::Tree,
     group_tree: sled::Tree,
     sequence: AtomicU64,
@@ -26,6 +30,7 @@ impl PluginManager {
     pub fn new(user_tree: sled::Tree, group_tree: sled::Tree) -> Self {
         Self {
             plugins: RwLock::new(HashMap::new()),
+            historical_plugins: RwLock::new(HashMap::new()),
             user_tree,
             group_tree,
             sequence: AtomicU64::new(1),
@@ -34,34 +39,39 @@ impl PluginManager {
     }
 
     pub fn register_plugin(&self, request: PluginRegistrationRequest) -> Result<PluginMetadata> {
-        if request.name.trim().is_empty() {
-            return Err(NovaError::validation_error("Plugin name cannot be empty"));
-        }
-        if request.endpoint.trim().is_empty() {
-            return Err(NovaError::validation_error(
-                "Plugin endpoint cannot be empty",
-            ));
-        }
+        self.register_plugin_internal(request, false)
+    }
 
-        let plugin_id = self.sequence.fetch_add(1, Ordering::SeqCst);
-        let metadata = PluginMetadata {
-            plugin_id,
-            name: request.name,
-            description: request.description,
-            owner_id: request.owner_id,
-            scopes: request.scopes,
-            endpoint: request.endpoint,
-            icon_url: request.icon_url,
-            trust_level: request.trust_level,
+    pub fn register_tool(
+        &self,
+        request: PluginRegistrationRequest,
+        owner_context: &RequestContext,
+    ) -> Result<ToolRegistrationResponse> {
+        let metadata = self.register_plugin_internal(request, true)?;
+
+        let mut enable_request = PluginEnableRequest {
+            context_type: owner_context.context_type.clone(),
+            context_id: owner_context.context_id.clone(),
+            plugin_id: metadata.plugin_id,
+            enable: true,
+            added_by: None,
         };
 
-        let mut guard = self
-            .plugins
-            .write()
-            .map_err(|_| NovaError::internal("Plugin registry lock poisoned"))?;
-        guard.insert(plugin_id, metadata.clone());
+        if matches!(enable_request.context_type, PluginContextType::Group) {
+            enable_request.added_by = Some(metadata.owner_id.clone());
+        }
 
-        Ok(metadata)
+        self.set_enablement(enable_request)?;
+
+        let fq_name = metadata.fully_qualified_name.clone().ok_or_else(|| {
+            NovaError::internal("Expected fully qualified name for contextual tool")
+        })?;
+
+        Ok(ToolRegistrationResponse {
+            plugin_id: metadata.plugin_id,
+            fully_qualified_name: fq_name,
+            version: metadata.version,
+        })
     }
 
     pub fn unregister_plugin(&self, plugin_id: u64) -> Result<()> {
@@ -122,6 +132,28 @@ impl PluginManager {
         if let Some(trust_level) = update.trust_level {
             plugin.trust_level = trust_level;
         }
+        if let Some(input_schema) = update.input_schema {
+            match input_schema {
+                Some(schema) => {
+                    Self::validate_schema(&schema)?;
+                    plugin.input_schema = Some(schema);
+                }
+                None => {
+                    plugin.input_schema = None;
+                }
+            }
+        }
+        if let Some(output_schema) = update.output_schema {
+            match output_schema {
+                Some(schema) => {
+                    Self::validate_schema(&schema)?;
+                    plugin.output_schema = Some(schema);
+                }
+                None => {
+                    plugin.output_schema = None;
+                }
+            }
+        }
 
         Ok(plugin.clone())
     }
@@ -143,6 +175,136 @@ impl PluginManager {
             .get(&plugin_id)
             .cloned()
             .ok_or_else(|| NovaError::plugin_not_found(plugin_id))
+    }
+
+    pub fn list_plugins_for_context(
+        &self,
+        context_type: PluginContextType,
+        context_id: &str,
+    ) -> Result<Vec<PluginMetadata>> {
+        let guard = self
+            .plugins
+            .read()
+            .map_err(|_| NovaError::internal("Plugin registry lock poisoned"))?;
+
+        let mut latest_by_name: HashMap<String, &PluginMetadata> = HashMap::new();
+
+        for metadata in guard.values() {
+            if metadata
+                .context_type
+                .as_ref()
+                .map(|ct| ct == &context_type)
+                .unwrap_or(false)
+                && metadata
+                    .context_id
+                    .as_ref()
+                    .map(|id| id == context_id)
+                    .unwrap_or(false)
+            {
+                let entry = latest_by_name
+                    .entry(metadata.name.clone())
+                    .or_insert(metadata);
+                if metadata.version > entry.version {
+                    latest_by_name.insert(metadata.name.clone(), metadata);
+                }
+            }
+        }
+
+        Ok(latest_by_name
+            .values()
+            .map(|meta| (*meta).clone())
+            .collect())
+    }
+
+    pub fn update_tool(
+        &self,
+        plugin_id: u64,
+        request: ToolUpdateRequest,
+        owner_context: &RequestContext,
+    ) -> Result<PluginMetadata> {
+        let mut guard = self
+            .plugins
+            .write()
+            .map_err(|_| NovaError::internal("Plugin registry lock poisoned"))?;
+
+        let plugin = guard
+            .get_mut(&plugin_id)
+            .ok_or_else(|| NovaError::plugin_not_found(plugin_id))?;
+
+        let original_metadata = plugin.clone();
+
+        let plugin_context = plugin
+            .context_type
+            .clone()
+            .ok_or_else(|| NovaError::validation_error("Plugin is not context scoped"))?;
+        let plugin_context_id = plugin
+            .context_id
+            .clone()
+            .ok_or_else(|| NovaError::validation_error("Plugin is not context scoped"))?;
+
+        let metadata_context = RequestContext {
+            context_type: plugin_context,
+            context_id: plugin_context_id.clone(),
+        };
+
+        require_matching_context(&metadata_context, owner_context)?;
+
+        if let Some(name) = request.name.clone() {
+            if name.trim().is_empty() {
+                return Err(NovaError::validation_error("Tool name cannot be empty"));
+            }
+            plugin.name = name;
+        }
+
+        if let Some(description) = request.description.clone() {
+            plugin.description = description;
+        }
+
+        if let Some(endpoint) = request.endpoint.clone() {
+            if endpoint.trim().is_empty() {
+                return Err(NovaError::validation_error(
+                    "Plugin endpoint cannot be empty",
+                ));
+            }
+            plugin.endpoint = endpoint;
+        }
+
+        if let Some(schema) = request.input_schema.clone() {
+            Self::validate_schema(&schema)?;
+            plugin.input_schema = Some(schema);
+        }
+
+        if let Some(output_schema) = request.output_schema.clone() {
+            match output_schema {
+                Some(schema) => {
+                    Self::validate_schema(&schema)?;
+                    plugin.output_schema = Some(schema);
+                }
+                None => plugin.output_schema = None,
+            }
+        }
+
+        if let Some(icon_url) = request.icon_url.clone() {
+            plugin.icon_url = icon_url;
+        }
+
+        if let Some(trust_level) = request.trust_level.clone() {
+            plugin.trust_level = trust_level;
+        }
+
+        plugin.version = original_metadata.version.saturating_add(1);
+        plugin.fully_qualified_name = Some(Self::format_fq_name(
+            &metadata_context.context_type,
+            &metadata_context.context_id,
+            &plugin.name,
+            plugin.version,
+        ));
+
+        if original_metadata.fully_qualified_name.is_some() {
+            self.archive_metadata(original_metadata)?;
+        }
+
+        Ok(plugin.clone())
     }
 
     pub fn set_enablement(&self, request: PluginEnableRequest) -> Result<PluginEnablementStatus> {
@@ -186,6 +348,10 @@ impl PluginManager {
             ));
         }
 
+        if let Some(schema) = metadata.input_schema.as_ref() {
+            Self::validate_against_schema(&arguments, schema)?;
+        }
+
         let payload = PluginInvocationPayload {
             context_type,
             context_id,
@@ -210,7 +376,35 @@ impl PluginManager {
         }
 
         let json = response.json().await.map_err(NovaError::from)?;
+
+        if let Some(schema) = metadata.output_schema.as_ref() {
+            Self::validate_against_schema(&json, schema)?;
+        }
+
         Ok(json)
+    }
+
+    pub fn get_plugin_by_fq_name(&self, fq_name: &str) -> Result<PluginMetadata> {
+        let guard = self
+            .plugins
+            .read()
+            .map_err(|_| NovaError::internal("Plugin registry lock poisoned"))?;
+        if let Some(metadata) = guard
+            .values()
+            .find(|meta| meta.fully_qualified_name.as_deref() == Some(fq_name))
+        {
+            return Ok(metadata.clone());
+        }
+        drop(guard);
+
+        let history = self
+            .historical_plugins
+            .read()
+            .map_err(|_| NovaError::internal("Historical registry lock poisoned"))?;
+        history
+            .get(fq_name)
+            .cloned()
+            .ok_or_else(|| NovaError::validation_error(format!("Tool not found: {}", fq_name)))
     }
 
     fn ensure_plugin_exists(&self, plugin_id: u64) -> Result<()> {
@@ -392,5 +586,257 @@ impl PluginManager {
             PluginContextType::User => "user".to_string(),
             PluginContextType::Group => "group".to_string(),
         }
+    }
+
+    fn register_plugin_internal(
+        &self,
+        request: PluginRegistrationRequest,
+        require_context: bool,
+    ) -> Result<PluginMetadata> {
+        let PluginRegistrationRequest {
+            name,
+            description,
+            owner_id,
+            scopes,
+            endpoint,
+            icon_url,
+            trust_level,
+            context_type,
+            context_id,
+            mut input_schema,
+            mut output_schema,
+            version,
+        } = request;
+
+        if name.trim().is_empty() {
+            return Err(NovaError::validation_error("Plugin name cannot be empty"));
+        }
+        if endpoint.trim().is_empty() {
+            return Err(NovaError::validation_error(
+                "Plugin endpoint cannot be empty",
+            ));
+        }
+
+        let context = match (context_type, context_id) {
+            (Some(ct), Some(id)) => {
+                validate_context_pair(&ct, &id)?;
+                Some((ct, id))
+            }
+            (None, None) => {
+                if require_context {
+                    return Err(NovaError::validation_error(
+                        "Context is required for tool registration",
+                    ));
+                }
+                None
+            }
+            _ => {
+                return Err(NovaError::validation_error(
+                    "context_type and context_id must both be provided",
+                ));
+            }
+        };
+
+        match (&context, &mut input_schema) {
+            (Some(_), Some(schema)) => Self::validate_schema(schema)?,
+            (Some(_), None) => {
+                return Err(NovaError::validation_error(
+                    "input_schema is required for contextual tools",
+                ))
+            }
+            (None, Some(schema)) => Self::validate_schema(schema)?,
+            (None, None) => {}
+        }
+
+        if let Some(schema) = output_schema.as_mut() {
+            Self::validate_schema(schema)?;
+        }
+
+        let version = if let Some(v) = version {
+            if v == 0 {
+                return Err(NovaError::validation_error(
+                    "version must be greater than zero",
+                ));
+            }
+            if let Some((ref ct, ref id)) = context {
+                self.ensure_version_available(ct, id, &name, v)?;
+            }
+            v
+        } else if let Some((ref ct, ref id)) = context {
+            self.next_version(ct, id, &name)?
+        } else {
+            1
+        };
+
+        let plugin_id = self.sequence.fetch_add(1, Ordering::SeqCst);
+
+        let fully_qualified_name = context
+            .as_ref()
+            .map(|(ct, id)| Self::format_fq_name(ct, id, &name, version));
+
+        let metadata = PluginMetadata {
+            plugin_id,
+            name,
+            description,
+            owner_id,
+            scopes,
+            endpoint,
+            icon_url,
+            trust_level,
+            context_type: context.as_ref().map(|(ct, _)| ct.clone()),
+            context_id: context.as_ref().map(|(_, id)| id.clone()),
+            input_schema,
+            output_schema,
+            version,
+            fully_qualified_name,
+        };
+
+        let mut guard = self
+            .plugins
+            .write()
+            .map_err(|_| NovaError::internal("Plugin registry lock poisoned"))?;
+
+        guard.insert(plugin_id, metadata.clone());
+
+        Ok(metadata)
+    }
+
+    fn archive_metadata(&self, metadata: PluginMetadata) -> Result<()> {
+        if let Some(fq_name) = metadata.fully_qualified_name.clone() {
+            let mut guard = self
+                .historical_plugins
+                .write()
+                .map_err(|_| NovaError::internal("Historical registry lock poisoned"))?;
+            guard.insert(fq_name, metadata);
+        }
+        Ok(())
+    }
+
+    fn ensure_version_available(
+        &self,
+        context_type: &PluginContextType,
+        context_id: &str,
+        name: &str,
+        version: u32,
+    ) -> Result<()> {
+        let guard = self
+            .plugins
+            .read()
+            .map_err(|_| NovaError::internal("Plugin registry lock poisoned"))?;
+        let conflict = guard.values().any(|meta| {
+            meta.context_type.as_ref() == Some(context_type)
+                && meta.context_id.as_deref() == Some(context_id)
+                && meta.name == name
+                && meta.version == version
+        });
+        drop(guard);
+
+        if conflict {
+            return Err(NovaError::validation_error(
+                "Tool version already exists for this context",
+            ));
+        }
+
+        let history = self
+            .historical_plugins
+            .read()
+            .map_err(|_| NovaError::internal("Historical registry lock poisoned"))?;
+        let conflict = history.values().any(|meta| {
+            meta.context_type.as_ref() == Some(context_type)
+                && meta.context_id.as_deref() == Some(context_id)
+                && meta.name == name
+                && meta.version == version
+        });
+
+        if conflict {
+            return Err(NovaError::validation_error(
+                "Tool version already archived for this context",
+            ));
+        }
+
+        Ok(())
+    }
+
+    fn next_version(
+        &self,
+        context_type: &PluginContextType,
+        context_id: &str,
+        name: &str,
+    ) -> Result<u32> {
+        let guard = self
+            .plugins
+            .read()
+            .map_err(|_| NovaError::internal("Plugin registry lock poisoned"))?;
+        let mut max_version = guard
+            .values()
+            .filter(|meta| {
+                meta.context_type.as_ref() == Some(context_type)
+                    && meta.context_id.as_deref() == Some(context_id)
+                    && meta.name == name
+            })
+            .map(|meta| meta.version)
+            .max()
+            .unwrap_or(0);
+        drop(guard);
+
+        let history = self
+            .historical_plugins
+            .read()
+            .map_err(|_| NovaError::internal("Historical registry lock poisoned"))?;
+        if let Some(history_max) = history
+            .values()
+            .filter(|meta| {
+                meta.context_type.as_ref() == Some(context_type)
+                    && meta.context_id.as_deref() == Some(context_id)
+                    && meta.name == name
+            })
+            .map(|meta| meta.version)
+            .max()
+        {
+            if history_max > max_version {
+                max_version = history_max;
+            }
+        }
+
+        Ok(max_version + 1)
+    }
+
+    fn format_fq_name(
+        context_type: &PluginContextType,
+        context_id: &str,
+        name: &str,
+        version: u32,
+    ) -> String {
+        match context_type {
+            PluginContextType::User => {
+                format!("user_{}_{}_v{}", context_id, name, version)
+            }
+            PluginContextType::Group => {
+                format!("group_{}_{}_v{}", context_id, name, version)
+            }
+        }
+    }
+
+    fn validate_schema(schema: &Value) -> Result<()> {
+        if !schema.is_object() {
+            return Err(NovaError::validation_error("Schemas must be JSON objects"));
+        }
+        JSONSchema::compile(schema)
+            .map_err(|err| NovaError::validation_error(format!("Invalid schema: {}", err)))?;
+        Ok(())
+    }
+
+    fn validate_against_schema(value: &Value, schema: &Value) -> Result<()> {
+        let compiled = JSONSchema::compile(schema)
+            .map_err(|err| NovaError::validation_error(format!("Invalid schema: {}", err)))?;
+        let result = compiled.validate(value);
+        if let Err(errors) = result {
+            let messages: Vec<String> = errors.map(|err| err.to_string()).collect();
+            return Err(NovaError::validation_error(format!(
+                "Payload does not match schema: {}",
+                messages.join(", ")
+            )));
+        }
+        Ok(())
     }
 }

--- a/src/plugins/mod.rs
+++ b/src/plugins/mod.rs
@@ -6,10 +6,10 @@ pub mod manager;
 pub use dto::{
     ErrorResponse, PluginContextType, PluginEnableRequest, PluginEnablementStatus,
     PluginInvocationPayload, PluginInvocationRequest, PluginMetadata, PluginRegistrationRequest,
-    PluginUpdateRequest,
+    PluginUpdateRequest, ToolRegistrationResponse, ToolUpdateRequest,
 };
 pub(crate) use handler::{
-    invoke_plugin, list_plugins, register_plugin, set_plugin_enablement, unregister_plugin,
-    update_plugin,
+    invoke_plugin, list_plugins, list_tools, register_plugin, register_tool, set_plugin_enablement,
+    unregister_plugin, update_plugin, update_tool,
 };
 pub use manager::PluginManager;

--- a/tests/invalid_tool_args.rs
+++ b/tests/invalid_tool_args.rs
@@ -15,8 +15,10 @@ async fn invalid_arguments_return_error() {
             "name": "get_gecko_networks",
             "arguments": "nope"
         })),
+        context_type: None,
+        context_id: None,
     };
-    let resp = handler::handle_request(&server, req).await;
+    let resp = handler::handle_request(&server, req, None).await;
     assert!(resp.result.is_none());
     if let Some(err) = resp.error {
         assert_eq!(err.code, -32603);

--- a/tests/public_integration.rs
+++ b/tests/public_integration.rs
@@ -13,7 +13,7 @@ async fn get_gecko_networks_live() {
         name: "get_gecko_networks".into(),
         arguments: json!({}),
     };
-    let res = server.handle_tool_call(call).await.unwrap();
+    let res = server.handle_tool_call(call, None).await.unwrap();
     assert!(res.content.contains("networks"));
 }
 

--- a/tests/server_list_tools.rs
+++ b/tests/server_list_tools.rs
@@ -5,7 +5,7 @@ use std::sync::Arc;
 #[test]
 fn list_tools_contains_expected() {
     let server = test_server();
-    let tools = server.get_tools();
+    let tools = server.get_tools(None);
     assert_eq!(tools.len(), 6);
     let names: Vec<_> = tools.iter().map(|t| t.name.as_str()).collect();
     assert!(names.contains(&"get_gecko_networks"));


### PR DESCRIPTION
## Summary
- add a context module to parse and validate request ownership details for tools
- extend plugin management, HTTP, and MCP flows to support context-scoped tool registration, listing, and invocation with schema validation and versioning
- expose new /tools endpoints, rate limiting by context, and adjust examples/tests for the updated APIs

## Testing
- cargo test

------
https://chatgpt.com/codex/tasks/task_e_68cbf19025b08321a7014fefa9204bd6