### PR TITLE
Add multi-tenant tool platform implementation

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -18,6 +18,20 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
+name = "ahash"
+version = "0.8.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5a15f179cd60c4584b8a8c596927aadc462e27f2ca70c04e0071964a73ba7a75"
+dependencies = [
+ "cfg-if",
+ "getrandom 0.3.3",
+ "once_cell",
+ "serde",
+ "version_check",
+ "zerocopy",
+]
+
+[[package]]
 name = "aho-corasick"
 version = "1.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -33,6 +47,56 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "819e7219dbd41043ac279b19830f2efc897156490d7fd6ea916720117ee66311"
 dependencies = [
  "libc",
+]
+
+[[package]]
+name = "anstream"
+version = "0.6.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3ae563653d1938f79b1ab1b5e668c87c76a9930414574a6583a7b7e11a8e6192"
+dependencies = [
+ "anstyle",
+ "anstyle-parse",
+ "anstyle-query",
+ "anstyle-wincon",
+ "colorchoice",
+ "is_terminal_polyfill",
+ "utf8parse",
+]
+
+[[package]]
+name = "anstyle"
+version = "1.0.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "862ed96ca487e809f1c8e5a8447f6ee2cf102f846893800b20cebdf541fc6bbd"
+
+[[package]]
+name = "anstyle-parse"
+version = "0.2.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4e7644824f0aa2c7b9384579234ef10eb7efb6a0deb83f9630a49594dd9c15c2"
+dependencies = [
+ "utf8parse",
+]
+
+[[package]]
+name = "anstyle-query"
+version = "1.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9e231f6134f61b71076a3eab506c379d4f36122f2af15a9ff04415ea4c3339e2"
+dependencies = [
+ "windows-sys 0.60.2",
+]
+
+[[package]]
+name = "anstyle-wincon"
+version = "3.0.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3e0633414522a32ffaac8ac6cc8f748e090c5717661fddeea04219e2344f5f2a"
+dependencies = [
+ "anstyle",
+ "once_cell_polyfill",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -163,6 +227,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9d297deb1925b89f2ccc13d7635fa0714f12c87adce1c75356b39ca9b7178567"
 
 [[package]]
+name = "bit-set"
+version = "0.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0700ddab506f33b20a03b13996eccd309a48e5ff77d0d95926aa0210fb4e95f1"
+dependencies = [
+ "bit-vec",
+]
+
+[[package]]
+name = "bit-vec"
+version = "0.6.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "349f9b6a179ed607305526ca489b34ad0a41aed5f7980fa90eb03160b69598fb"
+
+[[package]]
 name = "bitflags"
 version = "1.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -179,6 +258,12 @@ name = "bumpalo"
 version = "3.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "46c5e41b57b8bba42a04676d81cb89e9ee8e859a1a66f80a5a72e1cb76b34d43"
+
+[[package]]
+name = "bytecount"
+version = "0.6.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "175812e0be2bccb6abe50bb8d566126198344f707e304f45c648fd8f2cc0365e"
 
 [[package]]
 name = "byteorder"
@@ -223,6 +308,52 @@ dependencies = [
 ]
 
 [[package]]
+name = "clap"
+version = "4.5.47"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7eac00902d9d136acd712710d71823fb8ac8004ca445a89e73a41d45aa712931"
+dependencies = [
+ "clap_builder",
+ "clap_derive",
+]
+
+[[package]]
+name = "clap_builder"
+version = "4.5.47"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2ad9bbf750e73b5884fb8a211a9424a1906c1e156724260fdae972f31d70e1d6"
+dependencies = [
+ "anstream",
+ "anstyle",
+ "clap_lex",
+ "strsim",
+]
+
+[[package]]
+name = "clap_derive"
+version = "4.5.47"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bbfd7eae0b0f1a6e63d4b13c9c478de77c2eb546fba158ad50b4203dc24b9f9c"
+dependencies = [
+ "heck",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "clap_lex"
+version = "0.7.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b94f61472cee1439c0b966b47e3aca9ae07e45d070759512cd390ea2bebc6675"
+
+[[package]]
+name = "colorchoice"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b05b61dc5112cbb17e4b6cd61790d9845d13888356391624cbe7e41efeac1e75"
+
+[[package]]
 name = "core-foundation"
 version = "0.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -261,6 +392,15 @@ name = "crossbeam-utils"
 version = "0.8.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d0a5c400df2834b80a4c3327b3aad3a4c4cd4de0629063962b03235697506a28"
+
+[[package]]
+name = "deranged"
+version = "0.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d630bccd429a5bb5a64b5e94f693bfc48c9f8566418fda4c494cc94f911f87cc"
+dependencies = [
+ "powerfmt",
+]
 
 [[package]]
 name = "displaydoc"
@@ -305,6 +445,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "fancy-regex"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b95f7c0680e4142284cf8b22c14a476e87d61b004a3a0861872b32ef7ead40a2"
+dependencies = [
+ "bit-set",
+ "regex",
+]
+
+[[package]]
 name = "fastrand"
 version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -344,6 +494,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cb4cb245038516f5f85277875cdaa4f7d2c9a0fa0468de06ed190163b1581fcf"
 dependencies = [
  "percent-encoding",
+]
+
+[[package]]
+name = "fraction"
+version = "0.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3027ae1df8d41b4bed2241c8fdad4acc1e7af60c8e17743534b545e77182d678"
+dependencies = [
+ "lazy_static",
+ "num",
 ]
 
 [[package]]
@@ -415,6 +575,19 @@ dependencies = [
 
 [[package]]
 name = "getrandom"
+version = "0.2.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "335ff9f135e4384c8150d6f27c6daed433577f86b4750418338c01a1a2528592"
+dependencies = [
+ "cfg-if",
+ "js-sys",
+ "libc",
+ "wasi 0.11.1+wasi-snapshot-preview1",
+ "wasm-bindgen",
+]
+
+[[package]]
+name = "getrandom"
 version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "26145e563e54f2cadc477553f1ec5ee650b00862f0a58bcd12cbdc5f0ea2d2f4"
@@ -455,6 +628,12 @@ name = "hashbrown"
 version = "0.15.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9229cfe53dfd69f0609a49f65461bd93001ea1ef889cd5529dd176593f5338a1"
+
+[[package]]
+name = "heck"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
 
 [[package]]
 name = "http"
@@ -766,6 +945,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "469fb0b9cefa57e3ef31275ee7cacb78f2fdca44e4765491884a2b119d4eb130"
 
 [[package]]
+name = "is_terminal_polyfill"
+version = "1.70.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7943c866cc5cd64cbc25b2e01621d07fa8eb2a1a23160ee81ce38704e97b8ecf"
+
+[[package]]
+name = "iso8601"
+version = "0.6.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e1082f0c48f143442a1ac6122f67e360ceee130b967af4d50996e5154a45df46"
+dependencies = [
+ "nom",
+]
+
+[[package]]
 name = "itoa"
 version = "1.0.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -779,6 +973,36 @@ checksum = "0c0b063578492ceec17683ef2f8c5e89121fbd0b172cbc280635ab7567db2738"
 dependencies = [
  "once_cell",
  "wasm-bindgen",
+]
+
+[[package]]
+name = "jsonschema"
+version = "0.17.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2a071f4f7efc9a9118dfb627a0a94ef247986e1ab8606a4c806ae2b3aa3b6978"
+dependencies = [
+ "ahash",
+ "anyhow",
+ "base64",
+ "bytecount",
+ "clap",
+ "fancy-regex",
+ "fraction",
+ "getrandom 0.2.16",
+ "iso8601",
+ "itoa",
+ "memchr",
+ "num-cmp",
+ "once_cell",
+ "parking_lot 0.12.4",
+ "percent-encoding",
+ "regex",
+ "reqwest",
+ "serde",
+ "serde_json",
+ "time",
+ "url",
+ "uuid",
 ]
 
 [[package]]
@@ -892,6 +1116,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "nom"
+version = "8.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df9761775871bdef83bee530e60050f7e54b1105350d6884eb0fb4f46c2f9405"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
 name = "nova-mcp"
 version = "0.1.0"
 dependencies = [
@@ -900,6 +1133,7 @@ dependencies = [
  "chrono",
  "dotenvy",
  "hyper 1.7.0",
+ "jsonschema",
  "reqwest",
  "serde",
  "serde_json",
@@ -920,6 +1154,82 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d4a28e057d01f97e61255210fcff094d74ed0466038633e95017f5beb68e4399"
 dependencies = [
  "windows-sys 0.52.0",
+]
+
+[[package]]
+name = "num"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "35bd024e8b2ff75562e5f34e7f4905839deb4b22955ef5e73d2fea1b9813cb23"
+dependencies = [
+ "num-bigint",
+ "num-complex",
+ "num-integer",
+ "num-iter",
+ "num-rational",
+ "num-traits",
+]
+
+[[package]]
+name = "num-bigint"
+version = "0.4.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a5e44f723f1133c9deac646763579fdb3ac745e418f2a7af9cd0c431da1f20b9"
+dependencies = [
+ "num-integer",
+ "num-traits",
+]
+
+[[package]]
+name = "num-cmp"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "63335b2e2c34fae2fb0aa2cecfd9f0832a1e24b3b32ecec612c3426d46dc8aaa"
+
+[[package]]
+name = "num-complex"
+version = "0.4.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "73f88a1307638156682bada9d7604135552957b7818057dcef22705b4d509495"
+dependencies = [
+ "num-traits",
+]
+
+[[package]]
+name = "num-conv"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "51d515d32fb182ee37cda2ccdcb92950d6a3c2893aa280e540671c2cd0f3b1d9"
+
+[[package]]
+name = "num-integer"
+version = "0.1.46"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7969661fd2958a5cb096e56c8e1ad0444ac2bbcd0061bd28660485a44879858f"
+dependencies = [
+ "num-traits",
+]
+
+[[package]]
+name = "num-iter"
+version = "0.1.45"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1429034a0490724d0075ebb2bc9e875d6503c3cf69e235a8941aa757d83ef5bf"
+dependencies = [
+ "autocfg",
+ "num-integer",
+ "num-traits",
+]
+
+[[package]]
+name = "num-rational"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f83d14da390562dca69fc84082e73e548e1ad308d24accdedd2720017cb37824"
+dependencies = [
+ "num-bigint",
+ "num-integer",
+ "num-traits",
 ]
 
 [[package]]
@@ -945,6 +1255,12 @@ name = "once_cell"
 version = "1.21.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "42f5e15c9953c5e4ccceeb2e7382a716482c34515315f7b03532b8b4e8393d2d"
+
+[[package]]
+name = "once_cell_polyfill"
+version = "1.70.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a4895175b425cb1f87721b59f0f286c2092bd4af812243672510e1ac53e2e0ad"
 
 [[package]]
 name = "openssl"
@@ -1072,6 +1388,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "powerfmt"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "439ee305def115ba05938db6eb1644ff94165c5ab5e9420d1c1bcedbba909391"
+
+[[package]]
 name = "proc-macro2"
 version = "1.0.101"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1111,6 +1433,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5407465600fb0548f1442edf71dd20683c6ed326200ace4b1ef0763521bb3b77"
 dependencies = [
  "bitflags 2.9.4",
+]
+
+[[package]]
+name = "regex"
+version = "1.11.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "23d7fd106d8c02486a8d64e778353d1cffe08ce79ac2e82f540c86d0facf6912"
+dependencies = [
+ "aho-corasick",
+ "memchr",
+ "regex-automata",
+ "regex-syntax",
 ]
 
 [[package]]
@@ -1391,6 +1725,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a8f112729512f8e442d81f95a8a7ddf2b7c6b8a1a6f509a95864142b30cab2d3"
 
 [[package]]
+name = "strsim"
+version = "0.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
+
+[[package]]
 name = "syn"
 version = "2.0.106"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1452,7 +1792,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "15b61f8f20e3a6f7e0649d825294eaf317edce30f82cf6026e7e4cb9222a7d1e"
 dependencies = [
  "fastrand",
- "getrandom",
+ "getrandom 0.3.3",
  "once_cell",
  "rustix",
  "windows-sys 0.60.2",
@@ -1485,6 +1825,36 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f60246a4944f24f6e018aa17cdeffb7818b76356965d03b07d6a9886e8962185"
 dependencies = [
  "cfg-if",
+]
+
+[[package]]
+name = "time"
+version = "0.3.43"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "83bde6f1ec10e72d583d91623c939f623002284ef622b87de38cfd546cbf2031"
+dependencies = [
+ "deranged",
+ "num-conv",
+ "powerfmt",
+ "serde",
+ "time-core",
+ "time-macros",
+]
+
+[[package]]
+name = "time-core"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "40868e7c1d2f0b8d73e4a8c7f0ff63af4f6d19be117e90bd73eb1d62cf831c6b"
+
+[[package]]
+name = "time-macros"
+version = "0.2.24"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "30cfb0125f12d9c277f35663a0a33f8c30190f4e4574868a330595412d34ebf3"
+dependencies = [
+ "num-conv",
+ "time-core",
 ]
 
 [[package]]
@@ -1743,6 +2113,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6c140620e7ffbb22c2dee59cafe6084a59b5ffc27a8859a5f0d494b5d52b6be"
 
 [[package]]
+name = "utf8parse"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
+
+[[package]]
+name = "uuid"
+version = "1.18.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2f87b8aa10b915a06587d0dec516c282ff295b475d94abf425d62b57710070a2"
+dependencies = [
+ "js-sys",
+ "wasm-bindgen",
+]
+
+[[package]]
 name = "valuable"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1753,6 +2139,12 @@ name = "vcpkg"
 version = "0.2.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "accd4ea62f7bb7a82fe23066fb0957d48ef677f6eeb8215f372f52e48bb32426"
+
+[[package]]
+name = "version_check"
+version = "0.9.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
 
 [[package]]
 name = "want"
@@ -2231,6 +2623,26 @@ dependencies = [
  "quote",
  "syn",
  "synstructure",
+]
+
+[[package]]
+name = "zerocopy"
+version = "0.8.27"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0894878a5fa3edfd6da3f88c4805f4c8558e2b996227a3d864f47fe11e38282c"
+dependencies = [
+ "zerocopy-derive",
+]
+
+[[package]]
+name = "zerocopy-derive"
+version = "0.8.27"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "88d2b8d9c68ad2b9e4340d7832716a4d21a22a1154777ad56ea55c51a9cf3831"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,6 +18,7 @@ tokio = { version = "1.0", features = ["full"] }
 # Serialization
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
+jsonschema = "0.17"
 
 # HTTP client for API calls
 reqwest = { version = "0.11", features = ["json", "blocking"] }

--- a/documentation.md
+++ b/documentation.md
@@ -7,6 +7,110 @@
 - Auth: Optional API key required for HTTP, disabled for stdio.
 - Extras: Simple plugin registry with enablement per user/group (dev/demo), sled-backed state, basic rate limiting.
 
+## Multi-Tenant Tool Platform Upgrade
+
+Nova-MCP is evolving from a single-tenant demo into a context-aware, multi-tenant tool platform. The key goals of this upgrade are to let Telegram users and group chats own their own tools, surface only the tools that match the current caller, and maintain backward compatibility with the existing built-in GeckoTerminal tools and legacy plug-in APIs. The sections below capture the requirements and system changes that drive this transformation.
+
+### 1. Introduction & Scope
+
+- Built-in tools remain defined in Rust via `Tool { name, description, input_schema }` and are assembled in `NovaServer::get_tools()`.
+- Users or groups will be able to register their own tools. Registered tools must only be returned to the AI when the requester’s context matches the owning context.
+- A single API key still authenticates HTTP requests. Identity is now derived from new context headers so that the same key can serve multiple tenants.
+
+### 2. Current Architecture Snapshot
+
+- Built-in tools are hard-coded Rust structs.
+- The existing plug-in registry allows `/plugins/register` followed by `PluginEnableRequest` per user or group (Telegram IDs). Enablement uses sled-backed state.
+- Authentication currently relies on only a global API key. The upgrade must preserve existing behaviour while adding multi-tenant awareness.
+
+### 3. Revised Requirements
+
+- **Context-aware tools:** Every tool is owned by `(context_type, context_id)` where `context_type ∈ {User, Group}` and `context_id` is the Telegram identifier (negative for groups).
+- **Single API key:** HTTP callers still provide one shared key but must include `x-nova-context-type` and `x-nova-context-id` headers. JSON-RPC over stdio accepts optional `context_type` and `context_id` fields.
+- **Web dashboard:** A browser UI will manage schemas, registrations, updates, and enablement workflows for both individuals and groups.
+- **Backward compatibility:** Built-in tools and the legacy plug-in APIs continue to function.
+- **Security & isolation:** Nova validates request payloads against declared schemas and limits tool invocation to enabled contexts.
+
+### 4. Data Model Changes
+
+#### 4.1 Tool Definition (Revised)
+
+`PluginRegistrationRequest` gains additional metadata so Nova can invoke third-party endpoints while injecting the caller context itself:
+
+| Field | Type | Description |
+| --- | --- | --- |
+| `input_schema` | `serde_json::Value` | JSON schema describing tool arguments. |
+| `output_schema` | `Option<serde_json::Value>` | Optional JSON schema for the returned payload. |
+| `version` | `u32` | Tool definition version. |
+| `endpoint_url` | `String` | HTTPS endpoint Nova will call. Nova includes caller context and arguments in the request body. |
+
+Historically plug-in authors provided `context_type` and `context_id` during registration. The upgrade removes that requirement—Nova now injects the caller context at runtime. An internal `owner_id` can still represent the third-party account separate from Telegram identifiers.
+
+#### 4.2 Tool Namespacing
+
+Nova derives a fully qualified name (FQN) to avoid collisions across users and groups:
+
+```rust
+if context_type == User {
+    format!("user_{}_{}_v{}", context_id, name, version)
+} else {
+    format!("group_{}_{}_v{}", context_id, name, version)
+}
+```
+
+The MCP `tools/list` response returns this FQN in `Tool.name`, while descriptions can present user-friendly information.
+
+### 5. API & Protocol Changes
+
+#### 5.1 Context Identification
+
+- **Headers:** Every HTTP request must include `x-api-key`, `x-nova-context-type` (`user` or `group`), and `x-nova-context-id` (Telegram ID). Missing or invalid context yields an auth error.
+- **JSON-RPC:** Stdio requests may include `context_type`/`context_id` at the root of the payload.
+
+#### 5.2 Tool Registration
+
+- New endpoint `POST /tools/register` accepts the fields from §4.1.
+- The server validates schemas, ensures the context matches the caller, prevents name collisions, persists metadata (including `endpoint_url`), auto-enables the tool for its owner, and returns `{ plugin_id, fq_name, version }`.
+- Updates via `PUT /tools/:plugin_id` bump the version; older versions remain callable for compatibility.
+
+#### 5.3 Tool Listing
+
+- `tools/list` extracts the caller context, loads built-in tools, queries plug-ins matching `(context_type, context_id)`, and returns the combined list with FQNs.
+
+#### 5.4 Tool Invocation
+
+1. Parse the tool name. Built-ins continue to dispatch via existing handlers.
+2. For plug-ins, parse the FQN back into `(context_type, context_id, base_name, version)`.
+3. Ensure the caller context matches and the tool is enabled via `PluginEnableRequest` rules.
+4. Validate arguments against `input_schema`.
+5. Invoke `endpoint_url` with a `PluginInvocationRequest` containing context and arguments.
+6. Optionally validate responses against `output_schema`.
+
+#### 5.5 Legacy Plug-in Endpoints
+
+Existing `/plugins/*` routes remain for internal administration but `/tools/*` will be the primary surface for multi-tenant scenarios.
+
+### 6. Server Implementation Changes
+
+- **Auth middleware (`auth.rs`):** Require the new headers, validate context types, ensure IDs are numeric (negative for groups), and store the resolved context in request scope.
+- **Plug-in manager:** Extend `PluginMetadata` with context ownership, schemas, versioning, and `endpoint_url`. Add helpers such as `list_plugins_for_context` and `get_plugin_by_fq_name`, and automatically enable the owning context on registration.
+- **MCP handlers:** `NovaServer::get_tools()` now receives context, merges built-in and context-specific tools, and `handle_tool_call()` parses FQNs, enforces context checks, and routes to plug-in invocation logic with clear error messages.
+
+### 7. Web Dashboard
+
+- **Authentication:** UI collects the API key and context (user or group) and sends them with every request. Users can switch contexts from the dashboard.
+- **Tool creation workflow:** Select context, define tool metadata, build schemas with validation, provide an HTTPS `endpoint_url`, register via `/tools/register`, and optionally enable the tool for other contexts. Successful registration displays the FQN.
+- **Tool management:** Show tools for the active context (base name, version, status, created at). Allow enable/disable, cross-context enablement, edits (create new versions), deletion, and optional invocation logs.
+- **Implementation notes:** React SPA or standalone app backed by Nova API, environment-configurable base URLs, JSON editors for advanced schema editing, and version bumping when editing.
+
+### 8. Security & Governance
+
+- **Rate limiting:** Enforce per-context sliding window limits for registrations and invocations since all clients share one API key.
+- **Schema sanitisation:** Accept only valid, recognised JSON Schema keywords to avoid expensive validation or malicious payloads.
+- **Ownership enforcement:** Only the owner context may update/delete tools; group admin policies can extend permissions.
+- **Audit logs:** Track registration, edits, enablement, timestamps, context IDs, and IPs with admin visibility.
+- **Future extensibility:** Preserve the user/group distinction but leave room for additional context types (e.g., organisations).
+
 ## Architecture
 
 ```

--- a/examples/test_client.rs
+++ b/examples/test_client.rs
@@ -1,6 +1,6 @@
 // Minimal example: call GeckoTerminal tools directly via NovaServer
 use anyhow::Result;
-use nova_mcp::plugins::PluginManager;
+use nova_mcp::plugins::{PluginContextType, PluginManager, RequestContext};
 use nova_mcp::server::ToolCall;
 use nova_mcp::{NovaConfig, NovaServer};
 use serde_json::json;
@@ -11,8 +11,12 @@ async fn main() -> Result<()> {
     tracing_subscriber::fmt::init();
 
     let server = build_server()?;
+    let context = RequestContext {
+        context_type: PluginContextType::User,
+        context_id: "0".to_string(),
+    };
     println!("Available tools:");
-    for t in server.get_tools() {
+    for t in server.get_tools(&context)? {
         println!(" - {}: {}", t.name, t.description);
     }
 
@@ -22,7 +26,7 @@ async fn main() -> Result<()> {
     };
     println!(
         "gecko_networks -> {:?}",
-        server.handle_tool_call(networks).await?.content
+        server.handle_tool_call(networks, &context).await?.content
     );
 
     let trending = ToolCall {
@@ -31,7 +35,7 @@ async fn main() -> Result<()> {
     };
     println!(
         "trending_pools -> {:?}",
-        server.handle_tool_call(trending).await?.content
+        server.handle_tool_call(trending, &context).await?.content
     );
     Ok(())
 }
@@ -39,8 +43,9 @@ async fn main() -> Result<()> {
 fn build_server() -> Result<NovaServer> {
     let config = NovaConfig::default();
     let db = sled::Config::new().temporary(true).open()?;
+    let metadata_tree = db.open_tree("plugin_metadata")?;
     let user_tree = db.open_tree("user_plugins")?;
     let group_tree = db.open_tree("group_plugins")?;
-    let plugin_manager = Arc::new(PluginManager::new(user_tree, group_tree));
+    let plugin_manager = Arc::new(PluginManager::new(metadata_tree, user_tree, group_tree)?);
     Ok(NovaServer::new(config, plugin_manager))
 }

--- a/src/http.rs
+++ b/src/http.rs
@@ -1,5 +1,5 @@
-use crate::mcp::dto::{McpRequest, McpResponse};
-use crate::plugins::{self, PluginManager};
+use crate::mcp::dto::{McpError, McpRequest, McpResponse};
+use crate::plugins::{self, PluginContextType, PluginManager, RequestContext};
 use crate::{ApiKeyAuth, NovaConfig, NovaServer};
 use anyhow::Result;
 use axum::{
@@ -53,35 +53,31 @@ async fn handle_rpc(
         .get(header_name.as_str())
         .and_then(|v| v.to_str().ok());
     if !state.auth().validate(presented) {
-        let res = McpResponse {
-            jsonrpc: "2.0".to_string(),
-            id: None,
-            result: None,
-            error: Some(crate::mcp::dto::McpError {
-                code: StatusCode::UNAUTHORIZED.as_u16() as i32,
-                message: "Unauthorized".to_string(),
-                data: None,
-            }),
-        };
+        let res = rpc_error_response(None, StatusCode::UNAUTHORIZED, "Unauthorized");
         return Json(res);
     }
-    // Simple per-key rate limiting
-    let key = presented.unwrap_or("anonymous").to_string();
-    if let Some(code) = check_rate_limit(&state, &key).await {
-        let res = McpResponse {
-            jsonrpc: "2.0".to_string(),
-            id: None,
-            result: None,
-            error: Some(crate::mcp::dto::McpError {
-                code: code.as_u16() as i32,
-                message: "Rate limit exceeded".to_string(),
-                data: None,
-            }),
-        };
+
+    let context = match extract_context_from_headers(&headers, req.id.clone()) {
+        Ok(context) => context,
+        Err(response) => return Json(response),
+    };
+
+    let rate_key = format!(
+        "{}:{}",
+        match context.context_type {
+            PluginContextType::User => "user",
+            PluginContextType::Group => "group",
+        },
+        context.context_id
+    );
+
+    if let Some(code) = check_rate_limit(&state, &rate_key).await {
+        let res = rpc_error_response(req.id.clone(), code, "Rate limit exceeded");
         return Json(res);
     }
+
     let server = state.server();
-    let res = crate::mcp::handler::handle_request(server.as_ref(), req).await;
+    let res = crate::mcp::handler::handle_request(server.as_ref(), req, Some(context)).await;
     Json(res)
 }
 
@@ -116,6 +112,14 @@ pub async fn run_http_server(server: NovaServer, config: NovaConfig) -> Result<(
         .route("/plugins", get(plugins::list_plugins))
         .route("/plugins/:plugin_id/call", post(plugins::invoke_plugin))
         .route("/plugins/enable", post(plugins::set_plugin_enablement))
+        .route("/tools/register", post(plugins::register_plugin))
+        .route(
+            "/tools/:plugin_id",
+            delete(plugins::unregister_plugin).put(plugins::update_plugin),
+        )
+        .route("/tools", get(plugins::list_plugins))
+        .route("/tools/:plugin_id/call", post(plugins::invoke_plugin))
+        .route("/tools/enable", post(plugins::set_plugin_enablement))
         .layer(DefaultBodyLimit::max(1024 * 1024))
         .with_state(state);
 
@@ -126,6 +130,74 @@ pub async fn run_http_server(server: NovaServer, config: NovaConfig) -> Result<(
         tracing::error!("HTTP server error: {}", e);
     }
     Ok(())
+}
+
+fn extract_context_from_headers(
+    headers: &axum::http::HeaderMap,
+    id: Option<serde_json::Value>,
+) -> Result<RequestContext, McpResponse> {
+    let context_type = headers
+        .get("x-nova-context-type")
+        .and_then(|value| value.to_str().ok())
+        .map(|value| value.trim().to_lowercase());
+
+    let context_type = match context_type.as_deref() {
+        Some("user") => PluginContextType::User,
+        Some("group") => PluginContextType::Group,
+        _ => {
+            return Err(rpc_error_response(
+                id,
+                StatusCode::BAD_REQUEST,
+                "Invalid or missing x-nova-context-type",
+            ))
+        }
+    };
+
+    let context_id_value = headers
+        .get("x-nova-context-id")
+        .and_then(|value| value.to_str().ok())
+        .map(|value| value.trim().to_string());
+
+    let context_id = match context_id_value {
+        Some(ref value) if !value.is_empty() => value.clone(),
+        _ => {
+            return Err(rpc_error_response(
+                id,
+                StatusCode::BAD_REQUEST,
+                "Invalid or missing x-nova-context-id",
+            ))
+        }
+    };
+
+    if context_id.parse::<i64>().is_err() {
+        return Err(rpc_error_response(
+            id,
+            StatusCode::BAD_REQUEST,
+            "x-nova-context-id must be numeric",
+        ));
+    }
+
+    Ok(RequestContext {
+        context_type,
+        context_id,
+    })
+}
+
+fn rpc_error_response(
+    id: Option<serde_json::Value>,
+    status: StatusCode,
+    message: impl Into<String>,
+) -> McpResponse {
+    McpResponse {
+        jsonrpc: "2.0".to_string(),
+        id,
+        result: None,
+        error: Some(McpError {
+            code: status.as_u16() as i32,
+            message: message.into(),
+            data: None,
+        }),
+    }
 }
 
 #[derive(Clone, Debug)]

--- a/src/mcp/dto.rs
+++ b/src/mcp/dto.rs
@@ -26,6 +26,10 @@ pub struct McpRequest {
     pub id: Option<Value>,
     pub method: String,
     pub params: Option<Value>,
+    #[serde(default)]
+    pub context_type: Option<String>,
+    #[serde(default)]
+    pub context_id: Option<String>,
 }
 
 #[derive(Debug, Serialize, Deserialize)]

--- a/src/mcp/handler.rs
+++ b/src/mcp/handler.rs
@@ -1,3 +1,4 @@
+use crate::plugins::{PluginContextType, RequestContext};
 use crate::server::NovaServer;
 use crate::{
     error::NovaError,
@@ -9,48 +10,63 @@ use crate::{
     tools::search_pools::{search_pools, SearchPoolsInput},
     tools::trending_pools::{get_trending_pools, GetTrendingPoolsInput},
 };
+use axum::http::StatusCode;
 use serde_json::json;
 
 use super::dto::{McpError, McpRequest, McpResponse, ToolCall, ToolResult};
 
-pub async fn handle_request(server: &NovaServer, request: McpRequest) -> McpResponse {
+pub async fn handle_request(
+    server: &NovaServer,
+    request: McpRequest,
+    transport_context: Option<RequestContext>,
+) -> McpResponse {
     match request.method.as_str() {
-        "tools/list" => {
-            let tools = server.get_tools();
-            McpResponse {
-                jsonrpc: "2.0".to_string(),
-                id: request.id,
-                result: Some(json!({
-                    "tools": tools
-                })),
-                error: None,
-            }
-        }
+        "tools/list" => match resolve_context(&request, transport_context) {
+            Ok(context) => match server.get_tools(&context) {
+                Ok(tools) => McpResponse {
+                    jsonrpc: "2.0".to_string(),
+                    id: request.id,
+                    result: Some(json!({
+                        "tools": tools
+                    })),
+                    error: None,
+                },
+                Err(err) => error_response(
+                    request.id,
+                    StatusCode::INTERNAL_SERVER_ERROR,
+                    format!("Failed to load tools: {}", err),
+                ),
+            },
+            Err(response) => response,
+        },
         "tools/call" => {
-            if let Some(params) = request.params {
+            if let Some(params) = request.params.clone() {
                 if let Ok(tool_call) = serde_json::from_value::<ToolCall>(params) {
-                    match handle_tool_call(server, tool_call).await {
-                        Ok(result) => McpResponse {
-                            jsonrpc: "2.0".to_string(),
-                            id: request.id,
-                            result: Some(json!({
-                                "content": [
-                                    { "type": "text", "text": result.content }
-                                ],
-                                "isError": result.is_error
-                            })),
-                            error: None,
+                    match resolve_context(&request, transport_context.clone()) {
+                        Ok(context) => match handle_tool_call(server, tool_call, &context).await {
+                            Ok(result) => McpResponse {
+                                jsonrpc: "2.0".to_string(),
+                                id: request.id,
+                                result: Some(json!({
+                                    "content": [
+                                        { "type": "text", "text": result.content }
+                                    ],
+                                    "isError": result.is_error
+                                })),
+                                error: None,
+                            },
+                            Err(e) => McpResponse {
+                                jsonrpc: "2.0".to_string(),
+                                id: request.id,
+                                result: None,
+                                error: Some(McpError {
+                                    code: -32603,
+                                    message: format!("Tool execution failed: {}", e),
+                                    data: None,
+                                }),
+                            },
                         },
-                        Err(e) => McpResponse {
-                            jsonrpc: "2.0".to_string(),
-                            id: request.id,
-                            result: None,
-                            error: Some(McpError {
-                                code: -32603,
-                                message: format!("Tool execution failed: {}", e),
-                                data: None,
-                            }),
-                        },
+                        Err(response) => response,
                     }
                 } else {
                     McpResponse {
@@ -109,6 +125,7 @@ pub async fn handle_request(server: &NovaServer, request: McpRequest) -> McpResp
 pub(crate) async fn handle_tool_call(
     server: &NovaServer,
     tool_call: ToolCall,
+    context: &RequestContext,
 ) -> Result<ToolResult, NovaError> {
     tracing::info!("Handling tool call: {}", tool_call.name);
     let result = match tool_call.name.as_str() {
@@ -176,10 +193,25 @@ pub(crate) async fn handle_tool_call(
             serde_json::to_value(output)?
         }
         _ => {
-            return Err(NovaError::api_error(format!(
-                "Unknown tool: {}",
-                tool_call.name
-            )));
+            let (expected_type, expected_id, _base, _version) =
+                parse_fully_qualified_name(&tool_call.name)
+                    .ok_or_else(|| NovaError::api_error("Invalid tool name"))?;
+
+            let metadata = server
+                .plugin_manager()
+                .get_plugin_by_fq_name(&tool_call.name)?;
+
+            if metadata.context_type != expected_type || metadata.context_id != expected_id {
+                return Err(NovaError::api_error(
+                    "Tool context does not match registered owner",
+                ));
+            }
+
+            let response = server
+                .plugin_manager()
+                .invoke_plugin(&metadata, context, tool_call.arguments)
+                .await?;
+            response
         }
     };
 
@@ -187,4 +219,95 @@ pub(crate) async fn handle_tool_call(
         content: serde_json::to_string_pretty(&result)?,
         is_error: false,
     })
+}
+
+fn resolve_context(
+    request: &McpRequest,
+    transport_context: Option<RequestContext>,
+) -> Result<RequestContext, McpResponse> {
+    if let Some(context) = transport_context {
+        return Ok(context);
+    }
+
+    let context_type = request
+        .context_type
+        .as_ref()
+        .map(|value| value.trim().to_lowercase());
+    let context_id = request
+        .context_id
+        .as_ref()
+        .map(|value| value.trim().to_string());
+
+    let context_type = match context_type.as_deref() {
+        Some("user") => PluginContextType::User,
+        Some("group") => PluginContextType::Group,
+        _ => {
+            return Err(error_response(
+                request.id.clone(),
+                StatusCode::UNAUTHORIZED,
+                "Missing or invalid context_type",
+            ))
+        }
+    };
+
+    let context_id = match context_id {
+        Some(id) if !id.is_empty() => id,
+        _ => {
+            return Err(error_response(
+                request.id.clone(),
+                StatusCode::UNAUTHORIZED,
+                "Missing or invalid context_id",
+            ))
+        }
+    };
+
+    if context_id.parse::<i64>().is_err() {
+        return Err(error_response(
+            request.id.clone(),
+            StatusCode::UNAUTHORIZED,
+            "context_id must be numeric",
+        ));
+    }
+
+    Ok(RequestContext {
+        context_type,
+        context_id,
+    })
+}
+
+fn parse_fully_qualified_name(name: &str) -> Option<(PluginContextType, String, String, u32)> {
+    if let Some(stripped) = name.strip_prefix("user_") {
+        parse_name_parts(stripped)
+            .map(|(context_id, base, version)| (PluginContextType::User, context_id, base, version))
+    } else if let Some(stripped) = name.strip_prefix("group_") {
+        parse_name_parts(stripped).map(|(context_id, base, version)| {
+            (PluginContextType::Group, context_id, base, version)
+        })
+    } else {
+        None
+    }
+}
+
+fn parse_name_parts(input: &str) -> Option<(String, String, u32)> {
+    let (context_id, remainder) = input.split_once('_')?;
+    let (base, version_part) = remainder.rsplit_once("_v")?;
+    let version = version_part.parse::<u32>().ok()?;
+    Some((context_id.to_string(), base.to_string(), version))
+}
+
+fn error_response(
+    id: Option<serde_json::Value>,
+    status: StatusCode,
+    message: impl Into<String>,
+) -> McpResponse {
+    McpResponse {
+        jsonrpc: "2.0".to_string(),
+        id,
+        result: None,
+        error: Some(McpError {
+            code: status.as_u16() as i32,
+            message: message.into(),
+            data: None,
+        }),
+    }
 }

--- a/src/plugins/dto.rs
+++ b/src/plugins/dto.rs
@@ -1,15 +1,48 @@
 use serde::{Deserialize, Serialize};
 
+const fn default_plugin_version() -> u32 {
+    1
+}
+
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct PluginRegistrationRequest {
     pub name: String,
     pub description: String,
-    pub owner_id: String,
-    pub scopes: Vec<String>,
-    pub endpoint: String,
     #[serde(default)]
-    pub icon_url: Option<String>,
-    pub trust_level: String,
+    pub owner_id: Option<String>,
+    pub input_schema: serde_json::Value,
+    #[serde(default)]
+    pub output_schema: Option<serde_json::Value>,
+    pub endpoint_url: String,
+    #[serde(default = "default_plugin_version")]
+    pub version: u32,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, Default)]
+pub struct PluginUpdateRequest {
+    #[serde(default)]
+    pub description: Option<String>,
+    #[serde(default)]
+    pub owner_id: Option<String>,
+    #[serde(default)]
+    pub input_schema: Option<serde_json::Value>,
+    #[serde(default)]
+    pub output_schema: Option<Option<serde_json::Value>>,
+    #[serde(default)]
+    pub endpoint_url: Option<String>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, Hash)]
+#[serde(rename_all = "lowercase")]
+pub enum PluginContextType {
+    User,
+    Group,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, Hash)]
+pub struct RequestContext {
+    pub context_type: PluginContextType,
+    pub context_id: String,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -17,43 +50,22 @@ pub struct PluginMetadata {
     pub plugin_id: u64,
     pub name: String,
     pub description: String,
-    pub owner_id: String,
-    pub scopes: Vec<String>,
-    pub endpoint: String,
     #[serde(default)]
-    pub icon_url: Option<String>,
-    pub trust_level: String,
+    pub owner_id: Option<String>,
+    pub context_type: PluginContextType,
+    pub context_id: String,
+    pub fq_name: String,
+    pub version: u32,
+    pub input_schema: serde_json::Value,
+    #[serde(default)]
+    pub output_schema: Option<serde_json::Value>,
+    pub endpoint_url: String,
+    pub created_at: i64,
+    pub updated_at: i64,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, Default)]
-pub struct PluginUpdateRequest {
-    #[serde(default)]
-    pub name: Option<String>,
-    #[serde(default)]
-    pub description: Option<String>,
-    #[serde(default)]
-    pub owner_id: Option<String>,
-    #[serde(default)]
-    pub scopes: Option<Vec<String>>,
-    #[serde(default)]
-    pub endpoint: Option<String>,
-    #[serde(default)]
-    pub icon_url: Option<Option<String>>,
-    #[serde(default)]
-    pub trust_level: Option<String>,
-}
-
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
-#[serde(rename_all = "lowercase")]
-pub enum PluginContextType {
-    User,
-    Group,
-}
-
-#[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct PluginInvocationRequest {
-    pub context_type: PluginContextType,
-    pub context_id: String,
     #[serde(default)]
     pub arguments: serde_json::Value,
 }
@@ -105,4 +117,29 @@ pub struct GroupPluginRecord {
     #[serde(default)]
     pub added_by: Option<String>,
     pub consent_ts: i64,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct PluginVersionRecord {
+    pub version: u32,
+    pub fq_name: String,
+    pub input_schema: serde_json::Value,
+    #[serde(default)]
+    pub output_schema: Option<serde_json::Value>,
+    pub endpoint_url: String,
+    pub created_at: i64,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct StoredPluginRecord {
+    pub plugin_id: u64,
+    pub name: String,
+    pub description: String,
+    #[serde(default)]
+    pub owner_id: Option<String>,
+    pub context_type: PluginContextType,
+    pub context_id: String,
+    pub created_at: i64,
+    pub updated_at: i64,
+    pub versions: Vec<PluginVersionRecord>,
 }

--- a/src/plugins/helpers.rs
+++ b/src/plugins/helpers.rs
@@ -6,12 +6,15 @@ use axum::{
 use crate::error::NovaError;
 use crate::http::{check_rate_limit, AppState};
 
-use super::dto::ErrorResponse;
+use super::dto::{ErrorResponse, PluginContextType, RequestContext};
+
+const CONTEXT_TYPE_HEADER: &str = "x-nova-context-type";
+const CONTEXT_ID_HEADER: &str = "x-nova-context-id";
 
 pub(crate) async fn authorize_request(
     state: &AppState,
     headers: &HeaderMap,
-) -> Result<String, (StatusCode, Json<ErrorResponse>)> {
+) -> Result<RequestContext, (StatusCode, Json<ErrorResponse>)> {
     let header_name = state.auth().header_name().to_string();
     let presented = headers
         .get(header_name.as_str())
@@ -25,8 +28,62 @@ pub(crate) async fn authorize_request(
         return Err((StatusCode::UNAUTHORIZED, Json(body)));
     }
 
-    let key = presented.unwrap_or("anonymous").to_string();
-    if let Some(code) = check_rate_limit(state, &key).await {
+    let context_type = headers
+        .get(CONTEXT_TYPE_HEADER)
+        .and_then(|value| value.to_str().ok())
+        .map(|value| value.trim().to_lowercase());
+
+    let context_type = match context_type.as_deref() {
+        Some("user") => PluginContextType::User,
+        Some("group") => PluginContextType::Group,
+        _ => {
+            let body = ErrorResponse {
+                error: "Invalid or missing x-nova-context-type".to_string(),
+                details: None,
+            };
+            return Err((StatusCode::BAD_REQUEST, Json(body)));
+        }
+    };
+
+    let context_id_value = headers
+        .get(CONTEXT_ID_HEADER)
+        .and_then(|value| value.to_str().ok())
+        .map(|value| value.trim().to_string());
+
+    let context_id = match context_id_value {
+        Some(ref id) if !id.is_empty() => id.clone(),
+        _ => {
+            let body = ErrorResponse {
+                error: "Invalid or missing x-nova-context-id".to_string(),
+                details: None,
+            };
+            return Err((StatusCode::BAD_REQUEST, Json(body)));
+        }
+    };
+
+    if context_id.parse::<i64>().is_err() {
+        let body = ErrorResponse {
+            error: "x-nova-context-id must be a numeric identifier".to_string(),
+            details: None,
+        };
+        return Err((StatusCode::BAD_REQUEST, Json(body)));
+    }
+
+    let context = RequestContext {
+        context_type,
+        context_id,
+    };
+
+    let rate_key = format!(
+        "{}:{}",
+        match context.context_type {
+            PluginContextType::User => "user",
+            PluginContextType::Group => "group",
+        },
+        context.context_id
+    );
+
+    if let Some(code) = check_rate_limit(state, &rate_key).await {
         let body = ErrorResponse {
             error: "Rate limit exceeded".to_string(),
             details: None,
@@ -34,7 +91,7 @@ pub(crate) async fn authorize_request(
         return Err((code, Json(body)));
     }
 
-    Ok(key)
+    Ok(context)
 }
 
 pub(crate) fn map_error(err: NovaError) -> (StatusCode, Json<ErrorResponse>) {

--- a/src/plugins/manager.rs
+++ b/src/plugins/manager.rs
@@ -4,145 +4,295 @@ use std::sync::atomic::{AtomicU64, Ordering};
 use std::sync::RwLock;
 
 use chrono::Utc;
+use jsonschema::{Draft, JSONSchema};
 use reqwest::Client;
+use serde_json::Value;
 
 use crate::error::{NovaError, Result};
 
 use super::dto::{
     GroupPluginRecord, PluginContextType, PluginEnableRequest, PluginEnablementStatus,
-    PluginInvocationPayload, PluginInvocationRequest, PluginMetadata, PluginRegistrationRequest,
-    PluginUpdateRequest, UserPluginRecord,
+    PluginInvocationPayload, PluginMetadata, PluginRegistrationRequest, PluginUpdateRequest,
+    PluginVersionRecord, RequestContext, StoredPluginRecord, UserPluginRecord,
 };
 
 pub struct PluginManager {
-    plugins: RwLock<HashMap<u64, PluginMetadata>>,
+    metadata_tree: sled::Tree,
     user_tree: sled::Tree,
     group_tree: sled::Tree,
+    plugins: RwLock<HashMap<u64, StoredPluginRecord>>,
+    fq_index: RwLock<HashMap<String, (u64, u32)>>,
     sequence: AtomicU64,
     http_client: Client,
 }
 
 impl PluginManager {
-    pub fn new(user_tree: sled::Tree, group_tree: sled::Tree) -> Self {
-        Self {
-            plugins: RwLock::new(HashMap::new()),
+    pub fn new(
+        metadata_tree: sled::Tree,
+        user_tree: sled::Tree,
+        group_tree: sled::Tree,
+    ) -> Result<Self> {
+        let (plugins, fq_index, next_id) = Self::load_plugins(&metadata_tree)?;
+        Ok(Self {
+            metadata_tree,
             user_tree,
             group_tree,
-            sequence: AtomicU64::new(1),
+            plugins: RwLock::new(plugins),
+            fq_index: RwLock::new(fq_index),
+            sequence: AtomicU64::new(next_id),
             http_client: Client::new(),
-        }
+        })
     }
 
-    pub fn register_plugin(&self, request: PluginRegistrationRequest) -> Result<PluginMetadata> {
-        if request.name.trim().is_empty() {
-            return Err(NovaError::validation_error("Plugin name cannot be empty"));
-        }
-        if request.endpoint.trim().is_empty() {
-            return Err(NovaError::validation_error(
-                "Plugin endpoint cannot be empty",
-            ));
-        }
+    pub fn register_plugin(
+        &self,
+        context: &RequestContext,
+        request: PluginRegistrationRequest,
+    ) -> Result<PluginMetadata> {
+        self.validate_registration(&request)?;
+        let mut plugins = self
+            .plugins
+            .write()
+            .map_err(|_| NovaError::internal("Plugin registry lock poisoned"))?;
+
+        Self::ensure_unique_name(&plugins, context, &request.name)?;
 
         let plugin_id = self.sequence.fetch_add(1, Ordering::SeqCst);
-        let metadata = PluginMetadata {
+        let now = Utc::now().timestamp();
+        let fq_name = Self::fq_name(
+            &context.context_type,
+            &context.context_id,
+            &request.name,
+            request.version,
+        );
+
+        self.ensure_unique_fq_name(&fq_name)?;
+
+        let version_record = PluginVersionRecord {
+            version: request.version,
+            fq_name: fq_name.clone(),
+            input_schema: request.input_schema.clone(),
+            output_schema: request.output_schema.clone(),
+            endpoint_url: request.endpoint_url.clone(),
+            created_at: now,
+        };
+
+        let record = StoredPluginRecord {
             plugin_id,
             name: request.name,
             description: request.description,
             owner_id: request.owner_id,
-            scopes: request.scopes,
-            endpoint: request.endpoint,
-            icon_url: request.icon_url,
-            trust_level: request.trust_level,
+            context_type: context.context_type.clone(),
+            context_id: context.context_id.clone(),
+            created_at: now,
+            updated_at: now,
+            versions: vec![version_record.clone()],
         };
 
-        let mut guard = self
-            .plugins
-            .write()
-            .map_err(|_| NovaError::internal("Plugin registry lock poisoned"))?;
-        guard.insert(plugin_id, metadata.clone());
+        plugins.insert(plugin_id, record.clone());
+        drop(plugins);
 
-        Ok(metadata)
+        self.persist_plugin(&record)?;
+        self.insert_fq_mapping(&version_record, plugin_id);
+        self.ensure_owner_enablement(&record)?;
+
+        Ok(Self::to_metadata(&record, &version_record))
     }
 
-    pub fn unregister_plugin(&self, plugin_id: u64) -> Result<()> {
-        let mut guard = self
+    pub fn unregister_plugin(&self, context: &RequestContext, plugin_id: u64) -> Result<()> {
+        let mut plugins = self
             .plugins
             .write()
             .map_err(|_| NovaError::internal("Plugin registry lock poisoned"))?;
-        let removed = guard.remove(&plugin_id);
-        drop(guard);
 
-        if removed.is_none() {
-            return Err(NovaError::plugin_not_found(plugin_id));
+        let record = plugins
+            .get(&plugin_id)
+            .cloned()
+            .ok_or_else(|| NovaError::plugin_not_found(plugin_id))?;
+
+        if record.context_type != context.context_type || record.context_id != context.context_id {
+            return Err(NovaError::validation_error(
+                "Only the owner context can delete a tool",
+            ));
         }
 
+        plugins.remove(&plugin_id);
+        drop(plugins);
+
+        self.metadata_tree
+            .remove(plugin_id.to_be_bytes())
+            .map_err(NovaError::from)?;
+        self.metadata_tree.flush().map_err(NovaError::from)?;
+
+        self.remove_fq_mappings(&record);
         self.clear_plugin_entries(plugin_id)?;
         Ok(())
     }
 
     pub fn update_plugin(
         &self,
+        context: &RequestContext,
         plugin_id: u64,
         update: PluginUpdateRequest,
     ) -> Result<PluginMetadata> {
-        let mut guard = self
+        self.validate_update(&update)?;
+        let mut plugins = self
             .plugins
             .write()
             .map_err(|_| NovaError::internal("Plugin registry lock poisoned"))?;
-        let plugin = guard
+
+        let record = plugins
             .get_mut(&plugin_id)
             .ok_or_else(|| NovaError::plugin_not_found(plugin_id))?;
 
-        if let Some(name) = update.name {
-            if name.trim().is_empty() {
-                return Err(NovaError::validation_error("Plugin name cannot be empty"));
-            }
-            plugin.name = name;
-        }
-        if let Some(description) = update.description {
-            plugin.description = description;
-        }
-        if let Some(owner_id) = update.owner_id {
-            plugin.owner_id = owner_id;
-        }
-        if let Some(scopes) = update.scopes {
-            plugin.scopes = scopes;
-        }
-        if let Some(endpoint) = update.endpoint {
-            if endpoint.trim().is_empty() {
-                return Err(NovaError::validation_error(
-                    "Plugin endpoint cannot be empty",
-                ));
-            }
-            plugin.endpoint = endpoint;
-        }
-        if let Some(icon_url) = update.icon_url {
-            plugin.icon_url = icon_url;
-        }
-        if let Some(trust_level) = update.trust_level {
-            plugin.trust_level = trust_level;
+        if record.context_type != context.context_type || record.context_id != context.context_id {
+            return Err(NovaError::validation_error(
+                "Only the owner context can update a tool",
+            ));
         }
 
-        Ok(plugin.clone())
+        let previous_version = record
+            .versions
+            .last()
+            .ok_or_else(|| NovaError::internal("Plugin record has no versions"))?
+            .clone();
+
+        let new_version = previous_version.version + 1;
+        let now = Utc::now().timestamp();
+        let fq_name = Self::fq_name(
+            &record.context_type,
+            &record.context_id,
+            &record.name,
+            new_version,
+        );
+
+        self.ensure_unique_fq_name(&fq_name)?;
+
+        if let Some(description) = update.description {
+            record.description = description;
+        }
+        if let Some(owner_id) = update.owner_id {
+            record.owner_id = Some(owner_id);
+        }
+
+        let input_schema = update
+            .input_schema
+            .unwrap_or(previous_version.input_schema.clone());
+        let output_schema = match update.output_schema {
+            Some(value) => value,
+            None => previous_version.output_schema.clone(),
+        };
+        let endpoint_url = update
+            .endpoint_url
+            .unwrap_or(previous_version.endpoint_url.clone());
+
+        let version_record = PluginVersionRecord {
+            version: new_version,
+            fq_name: fq_name.clone(),
+            input_schema,
+            output_schema,
+            endpoint_url,
+            created_at: now,
+        };
+
+        record.updated_at = now;
+        record.versions.push(version_record.clone());
+
+        let stored = record.clone();
+        drop(plugins);
+
+        self.persist_plugin(&stored)?;
+        self.insert_fq_mapping(&version_record, plugin_id);
+
+        Ok(Self::to_metadata(&stored, &version_record))
+    }
+
+    pub fn list_plugins_for_context(
+        &self,
+        context: &RequestContext,
+    ) -> Result<Vec<PluginMetadata>> {
+        let plugins = self
+            .plugins
+            .read()
+            .map_err(|_| NovaError::internal("Plugin registry lock poisoned"))?;
+
+        let mut result = Vec::new();
+        for record in plugins.values() {
+            let owner_match = record.context_type == context.context_type
+                && record.context_id == context.context_id;
+            let enabled = if owner_match {
+                true
+            } else {
+                self.is_enabled(
+                    record.plugin_id,
+                    context.context_type.clone(),
+                    &context.context_id,
+                )?
+            };
+
+            if owner_match || enabled {
+                if let Some(version) = record.versions.last() {
+                    result.push(Self::to_metadata(record, version));
+                }
+            }
+        }
+
+        Ok(result)
     }
 
     pub fn list_plugins(&self) -> Result<Vec<PluginMetadata>> {
-        let guard = self
+        let plugins = self
             .plugins
             .read()
             .map_err(|_| NovaError::internal("Plugin registry lock poisoned"))?;
-        Ok(guard.values().cloned().collect())
+        let mut result = Vec::new();
+        for record in plugins.values() {
+            if let Some(version) = record.versions.last() {
+                result.push(Self::to_metadata(record, version));
+            }
+        }
+        Ok(result)
     }
 
     pub fn get_plugin(&self, plugin_id: u64) -> Result<PluginMetadata> {
-        let guard = self
+        let plugins = self
             .plugins
             .read()
             .map_err(|_| NovaError::internal("Plugin registry lock poisoned"))?;
-        guard
+        let record = plugins
             .get(&plugin_id)
+            .ok_or_else(|| NovaError::plugin_not_found(plugin_id))?;
+        let version = record
+            .versions
+            .last()
+            .ok_or_else(|| NovaError::internal("Plugin record has no versions"))?;
+        Ok(Self::to_metadata(record, version))
+    }
+
+    pub fn get_plugin_by_fq_name(&self, fq_name: &str) -> Result<PluginMetadata> {
+        let fq_index = self
+            .fq_index
+            .read()
+            .map_err(|_| NovaError::internal("Plugin registry lock poisoned"))?;
+        let (plugin_id, version) = fq_index
+            .get(fq_name)
             .cloned()
-            .ok_or_else(|| NovaError::plugin_not_found(plugin_id))
+            .ok_or_else(|| NovaError::api_error("Unknown tool"))?;
+        drop(fq_index);
+
+        let plugins = self
+            .plugins
+            .read()
+            .map_err(|_| NovaError::internal("Plugin registry lock poisoned"))?;
+        let record = plugins
+            .get(&plugin_id)
+            .ok_or_else(|| NovaError::plugin_not_found(plugin_id))?;
+        let version = record
+            .versions
+            .iter()
+            .find(|v| v.version == version)
+            .ok_or_else(|| NovaError::internal("Version index out of sync"))?;
+        Ok(Self::to_metadata(record, version))
     }
 
     pub fn set_enablement(&self, request: PluginEnableRequest) -> Result<PluginEnablementStatus> {
@@ -168,33 +318,36 @@ impl PluginManager {
 
     pub async fn invoke_plugin(
         &self,
-        plugin_id: u64,
-        request: PluginInvocationRequest,
-    ) -> Result<serde_json::Value> {
-        let metadata = self.get_plugin(plugin_id)?;
-        let PluginInvocationRequest {
-            context_type,
-            context_id,
-            arguments,
-        } = request;
-
-        if !self.is_enabled(plugin_id, context_type.clone(), &context_id)? {
+        metadata: &PluginMetadata,
+        caller: &RequestContext,
+        arguments: Value,
+    ) -> Result<Value> {
+        if caller.context_type == metadata.context_type && caller.context_id == metadata.context_id
+        {
+            // owner always enabled
+        } else if !self.is_enabled(
+            metadata.plugin_id,
+            caller.context_type.clone(),
+            &caller.context_id,
+        )? {
             return Err(NovaError::plugin_not_enabled(
-                plugin_id,
-                Self::context_type_label(&context_type),
-                context_id,
+                metadata.plugin_id,
+                Self::context_type_label(&caller.context_type),
+                caller.context_id.clone(),
             ));
         }
 
+        self.validate_instance(&metadata.input_schema, &arguments, "arguments")?;
+
         let payload = PluginInvocationPayload {
-            context_type,
-            context_id,
+            context_type: caller.context_type.clone(),
+            context_id: caller.context_id.clone(),
             arguments,
         };
 
         let response = self
             .http_client
-            .post(&metadata.endpoint)
+            .post(&metadata.endpoint_url)
             .json(&payload)
             .send()
             .await
@@ -210,18 +363,254 @@ impl PluginManager {
         }
 
         let json = response.json().await.map_err(NovaError::from)?;
+        if let Some(schema) = &metadata.output_schema {
+            self.validate_instance(schema, &json, "response")?;
+        }
         Ok(json)
     }
 
+    fn validate_registration(&self, request: &PluginRegistrationRequest) -> Result<()> {
+        if request.name.trim().is_empty() {
+            return Err(NovaError::validation_error("Plugin name cannot be empty"));
+        }
+        if request.description.trim().is_empty() {
+            return Err(NovaError::validation_error(
+                "Plugin description cannot be empty",
+            ));
+        }
+        if request.endpoint_url.trim().is_empty() {
+            return Err(NovaError::validation_error(
+                "Plugin endpoint cannot be empty",
+            ));
+        }
+        if !request.endpoint_url.starts_with("https://") {
+            return Err(NovaError::validation_error(
+                "Plugin endpoint must use HTTPS",
+            ));
+        }
+        if request.version == 0 {
+            return Err(NovaError::validation_error(
+                "Version must be greater than or equal to 1",
+            ));
+        }
+        self.validate_schema(&request.input_schema, "input_schema")?;
+        if let Some(schema) = &request.output_schema {
+            self.validate_schema(schema, "output_schema")?;
+        }
+        Ok(())
+    }
+
+    fn validate_update(&self, update: &PluginUpdateRequest) -> Result<()> {
+        if let Some(schema) = &update.input_schema {
+            self.validate_schema(schema, "input_schema")?;
+        }
+        if let Some(schema) = &update.output_schema {
+            if let Some(value) = schema {
+                self.validate_schema(value, "output_schema")?;
+            }
+        }
+        if let Some(endpoint) = &update.endpoint_url {
+            if endpoint.trim().is_empty() {
+                return Err(NovaError::validation_error(
+                    "Plugin endpoint cannot be empty",
+                ));
+            }
+            if !endpoint.starts_with("https://") {
+                return Err(NovaError::validation_error(
+                    "Plugin endpoint must use HTTPS",
+                ));
+            }
+        }
+        Ok(())
+    }
+
+    fn validate_schema(&self, schema: &Value, label: &str) -> Result<()> {
+        if !schema.is_object() {
+            return Err(NovaError::validation_error(format!(
+                "{} must be a JSON object",
+                label
+            )));
+        }
+        JSONSchema::options()
+            .with_draft(Draft::Draft7)
+            .compile(schema)
+            .map_err(|err| {
+                NovaError::validation_error(format!(
+                    "{} is not a valid JSON schema: {}",
+                    label, err
+                ))
+            })?;
+        Ok(())
+    }
+
+    fn validate_instance(&self, schema: &Value, instance: &Value, label: &str) -> Result<()> {
+        let compiled = JSONSchema::options()
+            .with_draft(Draft::Draft7)
+            .compile(schema)
+            .map_err(|err| {
+                NovaError::validation_error(format!("{} schema compilation failed: {}", label, err))
+            })?;
+        if let Err(errors) = compiled.validate(instance) {
+            let messages: Vec<String> = errors.map(|e| e.to_string()).collect();
+            return Err(NovaError::validation_error(format!(
+                "{} failed validation: {}",
+                label,
+                messages.join(", ")
+            )));
+        }
+        Ok(())
+    }
+
+    fn ensure_unique_name(
+        plugins: &HashMap<u64, StoredPluginRecord>,
+        context: &RequestContext,
+        name: &str,
+    ) -> Result<()> {
+        for record in plugins.values() {
+            if record.context_type == context.context_type
+                && record.context_id == context.context_id
+                && record.name.eq_ignore_ascii_case(name)
+            {
+                return Err(NovaError::validation_error(
+                    "A tool with this name already exists for the context",
+                ));
+            }
+        }
+        Ok(())
+    }
+
+    fn ensure_unique_fq_name(&self, fq_name: &str) -> Result<()> {
+        let fq_index = self
+            .fq_index
+            .read()
+            .map_err(|_| NovaError::internal("Plugin registry lock poisoned"))?;
+        if fq_index.contains_key(fq_name) {
+            return Err(NovaError::validation_error(
+                "A tool with this version already exists",
+            ));
+        }
+        Ok(())
+    }
+
+    fn insert_fq_mapping(&self, version: &PluginVersionRecord, plugin_id: u64) {
+        if let Ok(mut map) = self.fq_index.write() {
+            map.insert(version.fq_name.clone(), (plugin_id, version.version));
+        }
+    }
+
+    fn remove_fq_mappings(&self, record: &StoredPluginRecord) {
+        if let Ok(mut map) = self.fq_index.write() {
+            for version in &record.versions {
+                map.remove(&version.fq_name);
+            }
+        }
+    }
+
+    fn persist_plugin(&self, record: &StoredPluginRecord) -> Result<()> {
+        let encoded = serde_json::to_vec(record).map_err(NovaError::from)?;
+        self.metadata_tree
+            .insert(record.plugin_id.to_be_bytes(), encoded)
+            .map_err(NovaError::from)?;
+        self.metadata_tree.flush().map_err(NovaError::from)?;
+        Ok(())
+    }
+
+    fn ensure_owner_enablement(&self, record: &StoredPluginRecord) -> Result<()> {
+        match record.context_type {
+            PluginContextType::User => {
+                let key = Self::context_key(&record.context_id, record.plugin_id);
+                let now = Utc::now().timestamp();
+                let user_record = UserPluginRecord {
+                    enabled: true,
+                    consent_ts: now,
+                };
+                let encoded = serde_json::to_vec(&user_record).map_err(NovaError::from)?;
+                self.user_tree
+                    .insert(key, encoded)
+                    .map_err(NovaError::from)?;
+                self.user_tree.flush().map_err(NovaError::from)?;
+            }
+            PluginContextType::Group => {
+                let key = Self::context_key(&record.context_id, record.plugin_id);
+                let now = Utc::now().timestamp();
+                let group_record = GroupPluginRecord {
+                    enabled: true,
+                    added_by: None,
+                    consent_ts: now,
+                };
+                let encoded = serde_json::to_vec(&group_record).map_err(NovaError::from)?;
+                self.group_tree
+                    .insert(key, encoded)
+                    .map_err(NovaError::from)?;
+                self.group_tree.flush().map_err(NovaError::from)?;
+            }
+        }
+        Ok(())
+    }
+
     fn ensure_plugin_exists(&self, plugin_id: u64) -> Result<()> {
-        let guard = self
+        let plugins = self
             .plugins
             .read()
             .map_err(|_| NovaError::internal("Plugin registry lock poisoned"))?;
-        if guard.contains_key(&plugin_id) {
+        if plugins.contains_key(&plugin_id) {
             Ok(())
         } else {
             Err(NovaError::plugin_not_found(plugin_id))
+        }
+    }
+
+    fn load_plugins(
+        tree: &sled::Tree,
+    ) -> Result<(
+        HashMap<u64, StoredPluginRecord>,
+        HashMap<String, (u64, u32)>,
+        u64,
+    )> {
+        let mut plugins = HashMap::new();
+        let mut index = HashMap::new();
+        let mut max_id = 0u64;
+        for item in tree.iter() {
+            let entry = item.map_err(NovaError::from)?;
+            let id_bytes: [u8; 8] =
+                entry.0.as_ref().try_into().map_err(|_| {
+                    NovaError::internal("Failed to parse plugin id from metadata key")
+                })?;
+            let plugin_id = u64::from_be_bytes(id_bytes);
+            let record: StoredPluginRecord =
+                serde_json::from_slice(&entry.1).map_err(NovaError::from)?;
+            for version in &record.versions {
+                index.insert(version.fq_name.clone(), (plugin_id, version.version));
+            }
+            if plugin_id >= max_id {
+                max_id = plugin_id + 1;
+            }
+            plugins.insert(plugin_id, record);
+        }
+        Ok((plugins, index, max_id.max(1)))
+    }
+
+    fn read_user_enablement(&self, context_id: &str, plugin_id: u64) -> Result<bool> {
+        let key = Self::context_key(context_id, plugin_id);
+        let value = self.user_tree.get(&key).map_err(NovaError::from)?;
+        if let Some(bytes) = value {
+            let record: UserPluginRecord =
+                serde_json::from_slice(&bytes).map_err(NovaError::from)?;
+            Ok(record.enabled)
+        } else {
+            Ok(false)
+        }
+    }
+
+    fn read_group_enablement(&self, context_id: &str, plugin_id: u64) -> Result<bool> {
+        let key = Self::context_key(context_id, plugin_id);
+        let value = self.group_tree.get(&key).map_err(NovaError::from)?;
+        if let Some(bytes) = value {
+            let record: GroupPluginRecord =
+                serde_json::from_slice(&bytes).map_err(NovaError::from)?;
+            Ok(record.enabled)
+        } else {
+            Ok(false)
         }
     }
 
@@ -231,9 +620,7 @@ impl PluginManager {
         let existing = self.user_tree.get(&key).map_err(NovaError::from)?;
 
         let mut record = if let Some(value) = existing {
-            serde_json::from_slice::<UserPluginRecord>(&value).map_err(|e| {
-                NovaError::internal(format!("Failed to parse user plugin record: {}", e))
-            })?
+            serde_json::from_slice::<UserPluginRecord>(&value).map_err(NovaError::from)?
         } else {
             UserPluginRecord {
                 enabled: false,
@@ -248,9 +635,7 @@ impl PluginManager {
             record.enabled = false;
         }
 
-        let encoded = serde_json::to_vec(&record).map_err(|e| {
-            NovaError::internal(format!("Failed to encode user plugin record: {}", e))
-        })?;
+        let encoded = serde_json::to_vec(&record).map_err(NovaError::from)?;
         self.user_tree
             .insert(key, encoded)
             .map_err(NovaError::from)?;
@@ -275,9 +660,7 @@ impl PluginManager {
         let existing = self.group_tree.get(&key).map_err(NovaError::from)?;
 
         let mut record = if let Some(value) = existing {
-            serde_json::from_slice::<GroupPluginRecord>(&value).map_err(|e| {
-                NovaError::internal(format!("Failed to parse group plugin record: {}", e))
-            })?
+            serde_json::from_slice::<GroupPluginRecord>(&value).map_err(NovaError::from)?
         } else {
             GroupPluginRecord {
                 enabled: false,
@@ -299,9 +682,7 @@ impl PluginManager {
             record.enabled = false;
         }
 
-        let encoded = serde_json::to_vec(&record).map_err(|e| {
-            NovaError::internal(format!("Failed to encode group plugin record: {}", e))
-        })?;
+        let encoded = serde_json::to_vec(&record).map_err(NovaError::from)?;
         self.group_tree
             .insert(key, encoded)
             .map_err(NovaError::from)?;
@@ -315,32 +696,6 @@ impl PluginManager {
             consent_ts: record.consent_ts,
             added_by: record.added_by.clone(),
         })
-    }
-
-    fn read_user_enablement(&self, context_id: &str, plugin_id: u64) -> Result<bool> {
-        let key = Self::context_key(context_id, plugin_id);
-        let value = self.user_tree.get(&key).map_err(NovaError::from)?;
-        if let Some(bytes) = value {
-            let record: UserPluginRecord = serde_json::from_slice(&bytes).map_err(|e| {
-                NovaError::internal(format!("Failed to parse user plugin record: {}", e))
-            })?;
-            Ok(record.enabled)
-        } else {
-            Ok(false)
-        }
-    }
-
-    fn read_group_enablement(&self, context_id: &str, plugin_id: u64) -> Result<bool> {
-        let key = Self::context_key(context_id, plugin_id);
-        let value = self.group_tree.get(&key).map_err(NovaError::from)?;
-        if let Some(bytes) = value {
-            let record: GroupPluginRecord = serde_json::from_slice(&bytes).map_err(|e| {
-                NovaError::internal(format!("Failed to parse group plugin record: {}", e))
-            })?;
-            Ok(record.enabled)
-        } else {
-            Ok(false)
-        }
     }
 
     fn clear_plugin_entries(&self, plugin_id: u64) -> Result<()> {
@@ -387,10 +742,44 @@ impl PluginManager {
         format!("{}|{}", context_id, plugin_id).into_bytes()
     }
 
+    fn fq_name(
+        context_type: &PluginContextType,
+        context_id: &str,
+        name: &str,
+        version: u32,
+    ) -> String {
+        match context_type {
+            PluginContextType::User => {
+                format!("user_{}_{}_v{}", context_id, name, version)
+            }
+            PluginContextType::Group => {
+                format!("group_{}_{}_v{}", context_id, name, version)
+            }
+        }
+    }
+
     fn context_type_label(context_type: &PluginContextType) -> String {
         match context_type {
             PluginContextType::User => "user".to_string(),
             PluginContextType::Group => "group".to_string(),
+        }
+    }
+
+    fn to_metadata(record: &StoredPluginRecord, version: &PluginVersionRecord) -> PluginMetadata {
+        PluginMetadata {
+            plugin_id: record.plugin_id,
+            name: record.name.clone(),
+            description: record.description.clone(),
+            owner_id: record.owner_id.clone(),
+            context_type: record.context_type.clone(),
+            context_id: record.context_id.clone(),
+            fq_name: version.fq_name.clone(),
+            version: version.version,
+            input_schema: version.input_schema.clone(),
+            output_schema: version.output_schema.clone(),
+            endpoint_url: version.endpoint_url.clone(),
+            created_at: record.created_at,
+            updated_at: record.updated_at,
         }
     }
 }

--- a/src/plugins/mod.rs
+++ b/src/plugins/mod.rs
@@ -6,7 +6,7 @@ pub mod manager;
 pub use dto::{
     ErrorResponse, PluginContextType, PluginEnableRequest, PluginEnablementStatus,
     PluginInvocationPayload, PluginInvocationRequest, PluginMetadata, PluginRegistrationRequest,
-    PluginUpdateRequest,
+    PluginUpdateRequest, PluginVersionRecord, RequestContext, StoredPluginRecord,
 };
 pub(crate) use handler::{
     invoke_plugin, list_plugins, register_plugin, set_plugin_enablement, unregister_plugin,

--- a/tests/public_integration.rs
+++ b/tests/public_integration.rs
@@ -1,5 +1,5 @@
 // Integration tests that hit real public APIs. Marked ignored by default.
-use nova_mcp::plugins::PluginManager;
+use nova_mcp::plugins::{PluginContextType, PluginManager, RequestContext};
 use nova_mcp::server::ToolCall;
 use nova_mcp::{NovaConfig, NovaServer};
 use serde_json::json;
@@ -13,15 +13,22 @@ async fn get_gecko_networks_live() {
         name: "get_gecko_networks".into(),
         arguments: json!({}),
     };
-    let res = server.handle_tool_call(call).await.unwrap();
+    let context = RequestContext {
+        context_type: PluginContextType::User,
+        context_id: "0".to_string(),
+    };
+    let res = server.handle_tool_call(call, &context).await.unwrap();
     assert!(res.content.contains("networks"));
 }
 
 fn test_server() -> NovaServer {
     let config = NovaConfig::default();
     let db = sled::Config::new().temporary(true).open().unwrap();
+    let metadata_tree = db.open_tree("plugin_metadata").unwrap();
     let user_tree = db.open_tree("user_plugins").unwrap();
     let group_tree = db.open_tree("group_plugins").unwrap();
-    let plugin_manager = Arc::new(PluginManager::new(user_tree, group_tree));
+    let plugin_manager = Arc::new(
+        PluginManager::new(metadata_tree, user_tree, group_tree).expect("init plugin manager"),
+    );
     NovaServer::new(config, plugin_manager)
 }


### PR DESCRIPTION
## Summary
- add persisted plugin metadata, schema validation, and endpoint invocation to PluginManager
- require context headers, apply per-context rate limits, and expose /tools endpoints in HTTP server
- integrate context-aware tool listing/invocation throughout NovaServer, MCP handlers, examples, and tests

## Testing
- cargo check

------
https://chatgpt.com/codex/tasks/task_e_68cc1e83d3888321b15b64320e06c755